### PR TITLE
Support suspending callbacks in robot waiting helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- **Breaking binary change:** Robot waiting helpers accept suspending callbacks and enforce timeouts across callback execution and polling delays; existing Kotlin call sites remain source-compatible, but previously compiled consumers must recompile.
+
 ### Deprecated
 
 ### Removed

--- a/robot/public/api/android/public.api
+++ b/robot/public/api/android/public.api
@@ -46,12 +46,12 @@ public abstract interface class software/ralf/app/platform/robot/RootMatcherProv
 }
 
 public final class software/ralf/app/platform/robot/WaiterKt {
-	public static final fun waitFor-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun waitFor-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun waitUntil-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun waitUntil-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static final fun waitUntilCatching-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun waitUntilCatching-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun waitFor-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun waitFor-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun waitUntil-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun waitUntil-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun waitUntilCatching-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun waitUntilCatching-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class software/ralf/app/platform/robot/internal/RobotInternals {

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -26,12 +26,12 @@ public final class software/ralf/app/platform/robot/RobotKt {
 }
 
 public final class software/ralf/app/platform/robot/WaiterKt {
-	public static final fun waitFor-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun waitFor-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun waitUntil-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun waitUntil-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static final fun waitUntilCatching-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun waitUntilCatching-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun waitFor-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun waitFor-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun waitUntil-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun waitUntil-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun waitUntilCatching-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun waitUntilCatching-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class software/ralf/app/platform/robot/internal/RobotInternals {

--- a/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
+++ b/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
@@ -6,11 +6,16 @@ import assertk.assertThat
 import assertk.assertions.cause
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThan
 import assertk.assertions.isNotNull
 import assertk.assertions.messageContains
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 
 class WaiterTest {
 
@@ -43,6 +48,55 @@ class WaiterTest {
   }
 
   @Test
+  fun `waitUntil supports a suspending condition`() {
+    var counter = 0
+
+    waitUntil(condition = "Wait for suspending condition", delay = 10.milliseconds) {
+      delay(10.milliseconds)
+      ++counter == 3
+    }
+
+    assertThat(counter).isEqualTo(3)
+  }
+
+  @Test
+  fun `waitUntil times out while the condition is suspended`() {
+    val elapsed = measureTime {
+      assertFailure {
+          waitUntil(
+            condition = "Wait for suspended condition",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+            true
+          }
+        }
+        .messageContains("Waiting until 'Wait for suspended condition' never returned true.")
+    }
+
+    assertThat(elapsed).isLessThan(1.seconds)
+  }
+
+  @Test
+  fun `waitUntil times out during the polling delay`() {
+    val elapsed = measureTime {
+      assertFailure {
+          waitUntil(
+            condition = "Wait between attempts",
+            timeout = 100.milliseconds,
+            delay = 5.seconds,
+          ) {
+            false
+          }
+        }
+        .messageContains("Waiting until 'Wait between attempts' never returned true.")
+    }
+
+    assertThat(elapsed).isLessThan(1.seconds)
+  }
+
+  @Test
   fun `throwing an exception in waitUntil bubbles up`() {
     assertFailure {
         waitUntil(
@@ -54,6 +108,19 @@ class WaiterTest {
         }
       }
       .messageContains("Test exception")
+  }
+
+  @Test
+  fun `waitUntil does not swallow coroutine cancellation`() {
+    val cancellation = CancellationException("Test cancellation")
+
+    assertFailure {
+      waitUntil(condition = "Wait for canceled condition") { throw cancellation }
+    }
+      .all {
+        isInstanceOf<CancellationException>()
+        messageContains("Test cancellation")
+      }
   }
 
   @Test
@@ -75,6 +142,18 @@ class WaiterTest {
   }
 
   @Test
+  fun `waitUntilCatching supports a suspending condition`() {
+    var counter = 0
+
+    waitUntilCatching(condition = "Wait for suspending condition", delay = 10.milliseconds) {
+      delay(10.milliseconds)
+      check(++counter == 3) { "Suspending condition is not ready." }
+    }
+
+    assertThat(counter).isEqualTo(3)
+  }
+
+  @Test
   fun `waitUntilCatching throws an error when condition is never met`() {
     assertFailure {
       waitUntilCatching(
@@ -92,11 +171,85 @@ class WaiterTest {
   }
 
   @Test
+  fun `waitUntilCatching times out while the condition is suspended`() {
+    val elapsed = measureTime {
+      assertFailure {
+          waitUntilCatching(
+            condition = "Wait for suspended condition",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+          }
+        }
+        .messageContains("Waiting until 'Wait for suspended condition' never succeeded.")
+    }
+
+    assertThat(elapsed).isLessThan(1.seconds)
+  }
+
+  @Test
+  fun `waitUntilCatching preserves the last failure when a later attempt times out`() {
+    var counter = 0
+
+    assertFailure {
+      waitUntilCatching(
+        condition = "Wait for suspended condition",
+        timeout = 100.milliseconds,
+        delay = 10.milliseconds,
+      ) {
+        if (counter++ == 0) {
+          error("Last meaningful failure")
+        }
+
+        delay(5.seconds)
+      }
+    }
+      .all {
+        messageContains("Waiting until 'Wait for suspended condition' never succeeded.")
+        cause().isNotNull().messageContains("Last meaningful failure")
+      }
+  }
+
+  @Test
+  fun `waitUntilCatching does not swallow coroutine cancellation`() {
+    val cancellation = CancellationException("Test cancellation")
+    var counter = 0
+
+    assertFailure {
+      waitUntilCatching(condition = "Wait for canceled condition", delay = 10.milliseconds) {
+        if (counter++ == 0) {
+          error("Previous failure")
+        }
+
+        throw cancellation
+      }
+    }
+      .all {
+        isInstanceOf<CancellationException>()
+        messageContains("Test cancellation")
+      }
+  }
+
+  @Test
   fun `waitFor returns the result when the value is non-null within the timeout`() {
     var counter = 0
 
     val result =
       waitFor(condition = "Wait for result", timeout = 2.seconds, delay = 20.milliseconds) {
+        counter++.takeIf { it == 3 }
+      }
+
+    assertThat(result).isEqualTo(3)
+  }
+
+  @Test
+  fun `waitFor returns a value produced by a suspending callback`() {
+    var counter = 0
+
+    val result =
+      waitFor(condition = "Wait for suspending result", delay = 10.milliseconds) {
+        delay(10.milliseconds)
         counter++.takeIf { it == 3 }
       }
 
@@ -115,5 +268,39 @@ class WaiterTest {
         }
       }
       .messageContains("Waiting for 'Wait for result' never succeeded and the value is null.")
+  }
+
+  @Test
+  fun `waitFor times out while producing a result`() {
+    val elapsed = measureTime {
+      assertFailure {
+          waitFor<String>(
+            condition = "Wait for suspended result",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+            "result"
+          }
+        }
+        .messageContains(
+          "Waiting for 'Wait for suspended result' never succeeded and the value is null."
+        )
+    }
+
+    assertThat(elapsed).isLessThan(1.seconds)
+  }
+
+  @Test
+  fun `waitFor does not swallow coroutine cancellation`() {
+    val cancellation = CancellationException("Test cancellation")
+
+    assertFailure {
+      waitFor<String>(condition = "Wait for canceled result") { throw cancellation }
+    }
+      .all {
+        isInstanceOf<CancellationException>()
+        messageContains("Test cancellation")
+      }
   }
 }

--- a/robot/public/src/noWasmJsMain/kotlin/software/ralf/app/platform/robot/Waiter.kt
+++ b/robot/public/src/noWasmJsMain/kotlin/software/ralf/app/platform/robot/Waiter.kt
@@ -3,15 +3,18 @@ package software.ralf.app.platform.robot
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val defaultTimeout = 10.seconds
 private val defaultDelay = 15.milliseconds
 
 /**
- * Blocks the current thread until the given [block] returns true or the [timeout] occurs. [block]
- * is invoked multiple times with the given [delay] to check the condition. In case of a timeout an
+ * Blocks the current thread until the given suspending [block] returns true or the [timeout]
+ * occurs. [block] is invoked multiple times with the given [delay] to check the condition. The
+ * timeout includes time spent inside [block] and waiting between attempts. In case of a timeout an
  * [IllegalStateException] is thrown, because the app never transitioned into the expected state.
  * For better error messages [condition] describes what [block] is checking and waiting for.
  *
@@ -23,26 +26,26 @@ public fun waitUntil(
   condition: String,
   timeout: Duration = defaultTimeout,
   delay: Duration = defaultDelay,
-  block: () -> Boolean,
+  block: suspend () -> Boolean,
 ) {
-  val sleepCycles = (timeout / delay).toInt()
-
   runBlocking {
-    repeat(sleepCycles) {
-      if (!block()) {
-        delay(delay)
-      } else {
-        return@runBlocking
-      }
-    }
+    val succeeded =
+      withTimeoutOrNull(timeout) {
+        while (!block()) {
+          delay(delay)
+        }
 
-    check(block()) { "Waiting until '$condition' never returned true." }
+        true
+      }
+
+    check(succeeded == true) { "Waiting until '$condition' never returned true." }
   }
 }
 
 /**
- * Similar to [waitUntil], but allows [block] to throw any error when the condition isn't met. This
- * is helpful for example to wait for a UI element, e.g.
+ * Similar to [waitUntil], but allows the suspending [block] to throw any error when the condition
+ * isn't met. Coroutine cancellation is not retried. The last failed attempt is included as the
+ * cause when waiting times out. This is helpful for example to wait for a UI element, e.g.
  *
  * ```
  * waitUntilCatching("text is visible") {
@@ -55,36 +58,35 @@ public fun waitUntilCatching(
   condition: String,
   timeout: Duration = defaultTimeout,
   delay: Duration = defaultDelay,
-  block: () -> Unit,
+  block: suspend () -> Unit,
 ) {
   var lastException: Throwable? = null
   try {
     waitUntil(condition = condition, timeout = timeout, delay = delay) {
       try {
-        lastException = null
         block()
         true
+      } catch (exception: CancellationException) {
+        throw exception
       } catch (t: Throwable) {
         lastException = t
         false
       }
     }
   } catch (t: Throwable) {
-    if (lastException != null) {
-      throw IllegalStateException("Waiting until '$condition' never succeeded.", lastException)
-    } else {
-      throw t
-    }
+    throw t as? CancellationException
+      ?: IllegalStateException("Waiting until '$condition' never succeeded.", lastException ?: t)
   }
 }
 
 /**
- * Similar to [waitUntil], but allows [block] to throw any error when the condition isn't met. This
- * is helpful for example to wait for a UI element, e.g.
+ * Blocks the current thread until the suspending [block] returns a non-null value or [timeout]
+ * occurs. [block] is invoked multiple times with the given [delay] while it returns null. The
+ * timeout includes time spent inside [block] and waiting between attempts, e.g.
  *
  * ```
- * waitUntilCatching("text is visible") {
- *     seeViewWithText("Some text")
+ * val session = waitFor("user is authenticated") {
+ *     sessionManager.sessionFlow.first { it is AuthSession.Authenticated }
  * }
  * ```
  */
@@ -93,7 +95,7 @@ public fun <T : Any> waitFor(
   condition: String,
   timeout: Duration = defaultTimeout,
   delay: Duration = defaultDelay,
-  block: () -> T?,
+  block: suspend () -> T?,
 ): T {
   var result: T? = null
 
@@ -103,13 +105,13 @@ public fun <T : Any> waitFor(
       result != null
     }
   } catch (t: Throwable) {
-    if (result == null) {
-      throw IllegalStateException(
+    throw if (t is CancellationException || result != null) {
+      t
+    } else {
+      IllegalStateException(
         "Waiting for '$condition' never succeeded and the value is null.",
         t,
       )
-    } else {
-      throw t
     }
   }
 


### PR DESCRIPTION
Allow test robots to call suspending APIs without wrapping every call site in `runBlocking`, and enforce a real deadline even when callbacks suspend or retries are delayed. Preserve cancellation and actionable failure causes while documenting the binary API change for `:robot:public` consumers.