### PR TITLE
Preserve assertion failures from waitUntilCatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Enforce module structure dependency rules for Android and JVM test fixtures while allowing fixtures to use test-only modules.
+- Preserve assertion failures when `waitUntilCatching` times out so test runners report failed assertions correctly.
 
 ### Security
 

--- a/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
+++ b/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.messageContains
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -36,14 +37,14 @@ class WaiterTest {
   @Test
   fun `waitUntil throws an error when the condition is never met`() {
     assertFailure {
-        waitUntil(
-          condition = "Wait for test condition",
-          timeout = 200.milliseconds,
-          delay = 100.milliseconds,
-        ) {
-          false
-        }
+      waitUntil(
+        condition = "Wait for test condition",
+        timeout = 200.milliseconds,
+        delay = 100.milliseconds,
+      ) {
+        false
       }
+    }
       .messageContains("Waiting until 'Wait for test condition' never returned true.")
   }
 
@@ -63,15 +64,15 @@ class WaiterTest {
   fun `waitUntil times out while the condition is suspended`() {
     val elapsed = measureTime {
       assertFailure {
-          waitUntil(
-            condition = "Wait for suspended condition",
-            timeout = 100.milliseconds,
-            delay = 10.milliseconds,
-          ) {
-            delay(5.seconds)
-            true
-          }
+        waitUntil(
+          condition = "Wait for suspended condition",
+          timeout = 100.milliseconds,
+          delay = 10.milliseconds,
+        ) {
+          delay(5.seconds)
+          true
         }
+      }
         .messageContains("Waiting until 'Wait for suspended condition' never returned true.")
     }
 
@@ -82,14 +83,14 @@ class WaiterTest {
   fun `waitUntil times out during the polling delay`() {
     val elapsed = measureTime {
       assertFailure {
-          waitUntil(
-            condition = "Wait between attempts",
-            timeout = 100.milliseconds,
-            delay = 5.seconds,
-          ) {
-            false
-          }
+        waitUntil(
+          condition = "Wait between attempts",
+          timeout = 100.milliseconds,
+          delay = 5.seconds,
+        ) {
+          false
         }
+      }
         .messageContains("Waiting until 'Wait between attempts' never returned true.")
     }
 
@@ -99,14 +100,14 @@ class WaiterTest {
   @Test
   fun `throwing an exception in waitUntil bubbles up`() {
     assertFailure {
-        waitUntil(
-          condition = "Wait for test condition",
-          timeout = 200.milliseconds,
-          delay = 100.milliseconds,
-        ) {
-          error("Test exception")
-        }
+      waitUntil(
+        condition = "Wait for test condition",
+        timeout = 200.milliseconds,
+        delay = 100.milliseconds,
+      ) {
+        error("Test exception")
       }
+    }
       .messageContains("Test exception")
   }
 
@@ -154,6 +155,37 @@ class WaiterTest {
   }
 
   @Test
+  fun `waitUntilCatching retries assertion failures until the assertion passes`() {
+    var counter = 0
+
+    waitUntilCatching(
+      condition = "Wait for test assertion",
+      timeout = 2.seconds,
+      delay = 20.milliseconds,
+    ) {
+      assertThat(++counter).isEqualTo(5)
+    }
+
+    assertThat(counter).isEqualTo(5)
+  }
+
+  @Test
+  fun `waitUntilCatching rethrows the original assertion failure after the timeout`() {
+    val assertionError = AssertionError("Test assertion")
+
+    assertFailure {
+      waitUntilCatching(
+        condition = "Wait for test assertion",
+        timeout = 100.milliseconds,
+        delay = 20.milliseconds,
+      ) {
+        throw assertionError
+      }
+    }
+      .isSameInstanceAs(assertionError)
+  }
+
+  @Test
   fun `waitUntilCatching throws an error when condition is never met`() {
     assertFailure {
       waitUntilCatching(
@@ -174,14 +206,14 @@ class WaiterTest {
   fun `waitUntilCatching times out while the condition is suspended`() {
     val elapsed = measureTime {
       assertFailure {
-          waitUntilCatching(
-            condition = "Wait for suspended condition",
-            timeout = 100.milliseconds,
-            delay = 10.milliseconds,
-          ) {
-            delay(5.seconds)
-          }
+        waitUntilCatching(
+          condition = "Wait for suspended condition",
+          timeout = 100.milliseconds,
+          delay = 10.milliseconds,
+        ) {
+          delay(5.seconds)
         }
+      }
         .messageContains("Waiting until 'Wait for suspended condition' never succeeded.")
     }
 
@@ -212,6 +244,27 @@ class WaiterTest {
   }
 
   @Test
+  fun `waitUntilCatching preserves the last assertion when a later attempt times out`() {
+    val assertionError = AssertionError("Last meaningful assertion")
+    var counter = 0
+
+    assertFailure {
+      waitUntilCatching(
+        condition = "Wait for suspended assertion",
+        timeout = 100.milliseconds,
+        delay = 10.milliseconds,
+      ) {
+        if (counter++ == 0) {
+          throw assertionError
+        }
+
+        delay(5.seconds)
+      }
+    }
+      .isSameInstanceAs(assertionError)
+  }
+
+  @Test
   fun `waitUntilCatching does not swallow coroutine cancellation`() {
     val cancellation = CancellationException("Test cancellation")
     var counter = 0
@@ -220,6 +273,26 @@ class WaiterTest {
       waitUntilCatching(condition = "Wait for canceled condition", delay = 10.milliseconds) {
         if (counter++ == 0) {
           error("Previous failure")
+        }
+
+        throw cancellation
+      }
+    }
+      .all {
+        isInstanceOf<CancellationException>()
+        messageContains("Test cancellation")
+      }
+  }
+
+  @Test
+  fun `waitUntilCatching preserves cancellation after a previous assertion failure`() {
+    val cancellation = CancellationException("Test cancellation")
+    var counter = 0
+
+    assertFailure {
+      waitUntilCatching(condition = "Wait for canceled assertion", delay = 10.milliseconds) {
+        if (counter++ == 0) {
+          throw AssertionError("Previous assertion")
         }
 
         throw cancellation
@@ -259,14 +332,14 @@ class WaiterTest {
   @Test
   fun `waitFor throws an error when the result is null`() {
     assertFailure {
-        waitFor<Int>(
-          condition = "Wait for result",
-          timeout = 100.milliseconds,
-          delay = 20.milliseconds,
-        ) {
-          null
-        }
+      waitFor<Int>(
+        condition = "Wait for result",
+        timeout = 100.milliseconds,
+        delay = 20.milliseconds,
+      ) {
+        null
       }
+    }
       .messageContains("Waiting for 'Wait for result' never succeeded and the value is null.")
   }
 
@@ -274,17 +347,17 @@ class WaiterTest {
   fun `waitFor times out while producing a result`() {
     val elapsed = measureTime {
       assertFailure {
-          waitFor<String>(
-            condition = "Wait for suspended result",
-            timeout = 100.milliseconds,
-            delay = 10.milliseconds,
-          ) {
-            delay(5.seconds)
-            "result"
-          }
+        waitFor<String>(
+          condition = "Wait for suspended result",
+          timeout = 100.milliseconds,
+          delay = 10.milliseconds,
+        ) {
+          delay(5.seconds)
+          "result"
         }
+      }
         .messageContains(
-          "Waiting for 'Wait for suspended result' never succeeded and the value is null."
+          "Waiting for 'Wait for suspended result' never succeeded and the value is null.",
         )
     }
 

--- a/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
+++ b/robot/public/src/androidUnitTest/kotlin/software/ralf/app/platform/robot/WaiterTest.kt
@@ -37,14 +37,14 @@ class WaiterTest {
   @Test
   fun `waitUntil throws an error when the condition is never met`() {
     assertFailure {
-      waitUntil(
-        condition = "Wait for test condition",
-        timeout = 200.milliseconds,
-        delay = 100.milliseconds,
-      ) {
-        false
+        waitUntil(
+          condition = "Wait for test condition",
+          timeout = 200.milliseconds,
+          delay = 100.milliseconds,
+        ) {
+          false
+        }
       }
-    }
       .messageContains("Waiting until 'Wait for test condition' never returned true.")
   }
 
@@ -64,15 +64,15 @@ class WaiterTest {
   fun `waitUntil times out while the condition is suspended`() {
     val elapsed = measureTime {
       assertFailure {
-        waitUntil(
-          condition = "Wait for suspended condition",
-          timeout = 100.milliseconds,
-          delay = 10.milliseconds,
-        ) {
-          delay(5.seconds)
-          true
+          waitUntil(
+            condition = "Wait for suspended condition",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+            true
+          }
         }
-      }
         .messageContains("Waiting until 'Wait for suspended condition' never returned true.")
     }
 
@@ -83,14 +83,14 @@ class WaiterTest {
   fun `waitUntil times out during the polling delay`() {
     val elapsed = measureTime {
       assertFailure {
-        waitUntil(
-          condition = "Wait between attempts",
-          timeout = 100.milliseconds,
-          delay = 5.seconds,
-        ) {
-          false
+          waitUntil(
+            condition = "Wait between attempts",
+            timeout = 100.milliseconds,
+            delay = 5.seconds,
+          ) {
+            false
+          }
         }
-      }
         .messageContains("Waiting until 'Wait between attempts' never returned true.")
     }
 
@@ -100,14 +100,14 @@ class WaiterTest {
   @Test
   fun `throwing an exception in waitUntil bubbles up`() {
     assertFailure {
-      waitUntil(
-        condition = "Wait for test condition",
-        timeout = 200.milliseconds,
-        delay = 100.milliseconds,
-      ) {
-        error("Test exception")
+        waitUntil(
+          condition = "Wait for test condition",
+          timeout = 200.milliseconds,
+          delay = 100.milliseconds,
+        ) {
+          error("Test exception")
+        }
       }
-    }
       .messageContains("Test exception")
   }
 
@@ -174,14 +174,14 @@ class WaiterTest {
     val assertionError = AssertionError("Test assertion")
 
     assertFailure {
-      waitUntilCatching(
-        condition = "Wait for test assertion",
-        timeout = 100.milliseconds,
-        delay = 20.milliseconds,
-      ) {
-        throw assertionError
+        waitUntilCatching(
+          condition = "Wait for test assertion",
+          timeout = 100.milliseconds,
+          delay = 20.milliseconds,
+        ) {
+          throw assertionError
+        }
       }
-    }
       .isSameInstanceAs(assertionError)
   }
 
@@ -206,14 +206,14 @@ class WaiterTest {
   fun `waitUntilCatching times out while the condition is suspended`() {
     val elapsed = measureTime {
       assertFailure {
-        waitUntilCatching(
-          condition = "Wait for suspended condition",
-          timeout = 100.milliseconds,
-          delay = 10.milliseconds,
-        ) {
-          delay(5.seconds)
+          waitUntilCatching(
+            condition = "Wait for suspended condition",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+          }
         }
-      }
         .messageContains("Waiting until 'Wait for suspended condition' never succeeded.")
     }
 
@@ -249,18 +249,18 @@ class WaiterTest {
     var counter = 0
 
     assertFailure {
-      waitUntilCatching(
-        condition = "Wait for suspended assertion",
-        timeout = 100.milliseconds,
-        delay = 10.milliseconds,
-      ) {
-        if (counter++ == 0) {
-          throw assertionError
-        }
+        waitUntilCatching(
+          condition = "Wait for suspended assertion",
+          timeout = 100.milliseconds,
+          delay = 10.milliseconds,
+        ) {
+          if (counter++ == 0) {
+            throw assertionError
+          }
 
-        delay(5.seconds)
+          delay(5.seconds)
+        }
       }
-    }
       .isSameInstanceAs(assertionError)
   }
 
@@ -332,14 +332,14 @@ class WaiterTest {
   @Test
   fun `waitFor throws an error when the result is null`() {
     assertFailure {
-      waitFor<Int>(
-        condition = "Wait for result",
-        timeout = 100.milliseconds,
-        delay = 20.milliseconds,
-      ) {
-        null
+        waitFor<Int>(
+          condition = "Wait for result",
+          timeout = 100.milliseconds,
+          delay = 20.milliseconds,
+        ) {
+          null
+        }
       }
-    }
       .messageContains("Waiting for 'Wait for result' never succeeded and the value is null.")
   }
 
@@ -347,17 +347,17 @@ class WaiterTest {
   fun `waitFor times out while producing a result`() {
     val elapsed = measureTime {
       assertFailure {
-        waitFor<String>(
-          condition = "Wait for suspended result",
-          timeout = 100.milliseconds,
-          delay = 10.milliseconds,
-        ) {
-          delay(5.seconds)
-          "result"
+          waitFor<String>(
+            condition = "Wait for suspended result",
+            timeout = 100.milliseconds,
+            delay = 10.milliseconds,
+          ) {
+            delay(5.seconds)
+            "result"
+          }
         }
-      }
         .messageContains(
-          "Waiting for 'Wait for suspended result' never succeeded and the value is null.",
+          "Waiting for 'Wait for suspended result' never succeeded and the value is null."
         )
     }
 

--- a/robot/public/src/noWasmJsMain/kotlin/software/ralf/app/platform/robot/Waiter.kt
+++ b/robot/public/src/noWasmJsMain/kotlin/software/ralf/app/platform/robot/Waiter.kt
@@ -44,14 +44,17 @@ public fun waitUntil(
 
 /**
  * Similar to [waitUntil], but allows the suspending [block] to throw any error when the condition
- * isn't met. Coroutine cancellation is not retried. The last failed attempt is included as the
- * cause when waiting times out. This is helpful for example to wait for a UI element, e.g.
+ * isn't met. Coroutine cancellation is not retried. This is helpful for example to wait for a UI
+ * element, e.g.
  *
  * ```
  * waitUntilCatching("text is visible") {
  *     seeViewWithText("Some text")
  * }
  * ```
+ *
+ * If the timeout occurs while [block] throws an [AssertionError], the last assertion failure is
+ * rethrown unchanged. Other failures are included as the cause of an [IllegalStateException].
  */
 @Suppress("TooGenericExceptionCaught")
 public fun waitUntilCatching(
@@ -74,8 +77,12 @@ public fun waitUntilCatching(
       }
     }
   } catch (t: Throwable) {
-    throw t as? CancellationException
-      ?: IllegalStateException("Waiting until '$condition' never succeeded.", lastException ?: t)
+    val failure = lastException
+    throw when {
+      t is CancellationException -> t
+      failure is AssertionError -> failure
+      else -> IllegalStateException("Waiting until '$condition' never succeeded.", failure ?: t)
+    }
   }
 }
 


### PR DESCRIPTION
Rethrow the original `AssertionError` when `waitUntilCatching` times out so test runners classify unmet expectations as assertion failures instead of generic errors. Keep existing wrapping for other failures and document the behavior for robot consumers.