### PR TITLE
Enforce module structure rules for test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Enforce module structure dependency rules for Android and JVM test fixtures while allowing fixtures to use test-only modules.
+
 ### Security
 
 ### Other Notes & Contributions

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -31,6 +31,7 @@ public abstract class software/ralf/app/platform/gradle/ModuleStructureDependenc
 	public abstract fun getIgnoredOutputFile ()Ljava/io/File;
 	public abstract fun getModuleCompileClasspath ()Ljava/util/Set;
 	public abstract fun getModulePath ()Ljava/lang/String;
+	public abstract fun getTestFixtures ()Lorg/gradle/api/provider/Property;
 	public abstract fun setIgnoredOutputFile (Ljava/io/File;)V
 	public abstract fun setModuleCompileClasspath (Ljava/util/Set;)V
 	public abstract fun setModulePath (Ljava/lang/String;)V

--- a/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
+++ b/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
@@ -1,5 +1,6 @@
 package software.ralf.app.platform.gradle
 
+import com.android.build.api.variant.HasTestFixtures
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -29,6 +30,9 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
   /** Whether `:impl` dependencies within the same library are allowed. */
   @get:Input public abstract val allowLibraryImplToImplDependencies: Property<Boolean>
 
+  /** Whether the checked compile classpath belongs to test fixtures. */
+  @get:Input public abstract val testFixtures: Property<Boolean>
+
   /** An empty output makes the task work with up-to-date checks. */
   @Suppress("unused") @get:OutputFile @get:Optional public abstract var ignoredOutputFile: File
 
@@ -36,6 +40,7 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
     description = "Checks that our module structure dependency rules are followed."
     group = "Verification"
     allowLibraryImplToImplDependencies.convention(false)
+    testFixtures.convention(false)
   }
 
   @TaskAction
@@ -49,7 +54,7 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
     if (moduleType != ModuleType.APP && moduleType != ModuleType.IMPL_ROBOTS) {
       checkNoImplImport(moduleType)
     }
-    if (moduleType != ModuleType.TESTING && !moduleType.isRobotsModule) {
+    if (moduleType != ModuleType.TESTING && !moduleType.isRobotsModule && !testFixtures.get()) {
       checkNoTestingImport()
     }
     if (!moduleType.isRobotsModule) {
@@ -61,7 +66,10 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
   }
 
   private fun checkOnlyPublicModule() {
-    val forbiddenDependencies = moduleCompileClasspath.filter { it.moduleType != ModuleType.PUBLIC }
+    val forbiddenDependencies = moduleCompileClasspath.filter {
+      it.moduleType != ModuleType.PUBLIC &&
+        !(testFixtures.get() && it.moduleType == ModuleType.TESTING)
+    }
 
     if (forbiddenDependencies.isNotEmpty()) {
       throw GradleException(
@@ -170,7 +178,11 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
         }
       }
 
-      fun registerForConfiguration(taskSuffix: String, configuration: () -> Configuration) {
+      fun registerForConfiguration(
+        taskSuffix: String,
+        configuration: () -> Configuration,
+        isTestFixtures: Boolean = false,
+      ) {
         val checkTask =
           tasks.register(
             "$baseTaskName${taskSuffix.capitalize()}",
@@ -183,6 +195,7 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
             task.allowLibraryImplToImplDependencies.set(
               appPlatform.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed()
             )
+            task.testFixtures.set(isTestFixtures)
             task.moduleCompileClasspath =
               configuration()
                 .allDependencies
@@ -214,6 +227,15 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
             taskSuffix = "android${variant.name.capitalize()}",
             configuration = { variant.compileConfiguration },
           )
+
+          val testFixtures = (variant as? HasTestFixtures)?.testFixtures
+          if (testFixtures != null) {
+            registerForConfiguration(
+              taskSuffix = "android${variant.name.capitalize()}TestFixtures",
+              configuration = { testFixtures.compileConfiguration },
+              isTestFixtures = true,
+            )
+          }
         }
       }
 
@@ -241,6 +263,14 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
           taskSuffix = "jvm",
           configuration = { configurations.getByName("compileClasspath") },
         )
+
+        plugins.withId("java-test-fixtures") {
+          registerForConfiguration(
+            taskSuffix = "jvmTestFixtures",
+            configuration = { configurations.getByName("testFixturesCompileClasspath") },
+            isTestFixtures = true,
+          )
+        }
       }
     }
   }

--- a/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/ModuleStructurePluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/ModuleStructurePluginTest.kt
@@ -1,12 +1,15 @@
 package software.ralf.app.platform.gradle
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
 import kotlin.test.Test
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.project.ProjectInternal
@@ -147,6 +150,82 @@ class ModuleStructurePluginTest {
     project.assertHasPublicModuleDependency()
   }
 
+  @Test
+  fun `test fixture checks are included in module structure checks`() {
+    val project = createPublicModule()
+    project.plugins.apply("java-test-fixtures")
+
+    project.appPlatform.enableModuleStructure(true)
+    project.evaluate()
+
+    val moduleStructureCheckTask = project.tasks.named("checkModuleStructureDependencies").get()
+    val testFixturesCheckTask = project.testFixturesDependencyCheckTask()
+
+    assertThat(moduleStructureCheckTask.taskDependencies.getDependencies(moduleStructureCheckTask))
+      .contains(testFixturesCheckTask)
+  }
+
+  @Test
+  fun `public test fixtures cannot depend on an impl module`() {
+    val project = createPublicModule()
+    project.plugins.apply("java-test-fixtures")
+    project.dependencies.add("testFixturesImplementation", project.project(":library:impl"))
+
+    project.appPlatform.enableModuleStructure(true)
+    project.evaluate()
+
+    val task = project.testFixturesDependencyCheckTask()
+    assertFailure { task.checkDependencies() }.isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `public test fixture api dependencies cannot include an impl module`() {
+    val project = createPublicModule()
+    project.plugins.apply("java-test-fixtures")
+    project.dependencies.add("testFixturesApi", project.project(":library:impl"))
+
+    project.appPlatform.enableModuleStructure(true)
+    project.evaluate()
+
+    val task = project.testFixturesDependencyCheckTask()
+    assertFailure { task.checkDependencies() }.isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `public test fixtures can depend on testing modules`() {
+    val project = createPublicModule()
+    project.plugins.apply("java-test-fixtures")
+    project.dependencies.add("testFixturesImplementation", project.project(":library:testing"))
+
+    project.appPlatform.enableModuleStructure(true)
+    project.evaluate()
+
+    project.testFixturesDependencyCheckTask().checkDependencies()
+  }
+
+  @Test
+  fun `test fixtures can be enabled after module structure`() {
+    val project = createPublicModule()
+    project.appPlatform.enableModuleStructure(true)
+
+    project.plugins.apply("java-test-fixtures")
+    project.evaluate()
+
+    assertThat(project.tasks.names).contains("checkModuleStructureDependenciesJvmTestFixtures")
+  }
+
+  @Test
+  fun `disabled dependency checks also skip test fixture checks`() {
+    val project = createPublicModule()
+    project.plugins.apply("java-test-fixtures")
+
+    project.appPlatform.enableModuleStructure { options -> options.enableDependencyCheck(false) }
+    project.evaluate()
+
+    val task = project.testFixturesDependencyCheckTask()
+    assertThat(task.onlyIf.isSatisfiedBy(task)).isFalse()
+  }
+
   private fun createImplModule(): Project {
     val rootProject = ProjectBuilder.builder().withName("root").build()
     val libraryProject =
@@ -160,12 +239,34 @@ class ModuleStructurePluginTest {
     return project
   }
 
+  private fun createPublicModule(): Project {
+    val rootProject = ProjectBuilder.builder().withName("root").build()
+    val libraryProject =
+      ProjectBuilder.builder().withName("library").withParent(rootProject).build()
+    ProjectBuilder.builder().withName("impl").withParent(libraryProject).build()
+    ProjectBuilder.builder().withName("testing").withParent(libraryProject).build()
+
+    val project = ProjectBuilder.builder().withName("public").withParent(libraryProject).build()
+    project.plugins.apply(PluginIds.KOTLIN_JVM)
+    project.configurations.maybeCreate("compileClasspath")
+    project.plugins.apply(AppPlatformPlugin::class.java)
+    return project
+  }
+
   private val Project.archivesName: Property<String>
     get() = extensions.getByType(BasePluginExtension::class.java).archivesName
 
   private fun Project.dependencyCheckTask(): ModuleStructureDependencyCheckTask =
     tasks
       .named("checkModuleStructureDependenciesJvm", ModuleStructureDependencyCheckTask::class.java)
+      .get()
+
+  private fun Project.testFixturesDependencyCheckTask(): ModuleStructureDependencyCheckTask =
+    tasks
+      .named(
+        "checkModuleStructureDependenciesJvmTestFixtures",
+        ModuleStructureDependencyCheckTask::class.java,
+      )
       .get()
 
   private fun Project.evaluate() {


### PR DESCRIPTION
Prevent Android and JVM test fixtures from bypassing architectural boundaries, where `:public` modules could otherwise pull in forbidden `:impl` dependencies. Preserve legitimate `:testing` dependencies so shared test helpers remain usable without leaking implementation details.