### PR TITLE
Support robots in child scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Allow robots to be contributed to any scope and find them automatically in child scopes during tests.
+
 ### Changed
 
 - **Breaking binary change:** Robot waiting helpers accept suspending callbacks and enforce timeouts across callback execution and polling delays; existing Kotlin call sites remain source-compatible, but previously compiled consumers must recompile.

--- a/di-common/public/src/commonMain/kotlin/software/ralf/app/platform/inject/robot/ContributesRobot.kt
+++ b/di-common/public/src/commonMain/kotlin/software/ralf/app/platform/inject/robot/ContributesRobot.kt
@@ -26,8 +26,6 @@ import software.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotatio
  *     ...
  * }
  * ```
- *
- * **ATTENTION:** Only `AppScope` is supported for now.
  */
 @ContributingAnnotation
 public annotation class ContributesRobot(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -302,6 +302,10 @@ class ConnectionRobot : Robot {
 or `composeRobot<Type>()` function. The annotation makes sure that the robots are added to the Metro
 or `kotlin-inject-anvil` dependency graph.
 
+Robots can be contributed to the application scope or any child scope. Robot lookup starts at the application scope
+and searches its children automatically. If multiple sibling scope instances provide the requested robot, lookup
+fails because the intended scope instance would be ambiguous.
+
 ??? info "Generated code"
 
     The `@ContributesRobot` annotation generates following code.
@@ -324,13 +328,17 @@ or `kotlin-inject-anvil` dependency graph.
               MetricsRobot(metricsService)
           }
         }
+
+        @ContributesTo(AppScope::class)
+        @Origin(MetricsRobot::class)
+        public interface MetricsRobotGraphContribution : RobotGraph
         ```
 
     === "kotlin-inject-anvil"
 
         ```kotlin
         @ContributesTo(AppScope::class)
-        public interface MetricsRobotComponent {
+        public interface MetricsRobotComponent : RobotComponent {
           @Provides
           public fun provideMetricsRobot(metricsService: FakeMetricsService): MetricsRobot =
             MetricsRobot(metricsService)

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/inject/processor/ContributesRobotProcessor.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/inject/processor/ContributesRobotProcessor.kt
@@ -31,7 +31,6 @@ import kotlin.reflect.KClass
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.IntoMap
 import me.tatarka.inject.annotations.Provides
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 import software.ralf.app.platform.inject.APP_PLATFORM_LOOKUP_PACKAGE
 import software.ralf.app.platform.inject.KotlinInjectContextAware
@@ -69,6 +68,8 @@ internal class ContributesRobotProcessor(
 
   private val robotClassName = ClassName("software.ralf.app.platform.robot", "Robot")
   private val robotFqName = robotClassName.canonicalName
+  private val robotComponentClassName =
+    ClassName("software.ralf.app.platform.robot", "RobotComponent")
 
   override fun process(resolver: Resolver): List<KSAnnotated> {
     resolver
@@ -78,7 +79,6 @@ internal class ContributesRobotProcessor(
         checkIsPublic(it)
         checkNotSingleton(it)
         checkSuperType(it)
-        checkAppScope(it)
         checkSingleConstructorOrInject(it)
       }
       .forEach { generateComponentInterface(it) }
@@ -95,6 +95,7 @@ internal class ContributesRobotProcessor(
         .addType(
           TypeSpec.interfaceBuilder(componentClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
+            .addSuperinterface(robotComponentClassName)
             .addOriginAnnotation(clazz)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
@@ -158,13 +159,6 @@ internal class ContributesRobotProcessor(
     check(extendsRobot, clazz) {
       "In order to use @ContributesRobot, ${clazz.simpleName.asString()} must " +
         "implement $robotFqName."
-    }
-  }
-
-  private fun checkAppScope(clazz: KSClassDeclaration) {
-    val scope = clazz.scope().type.declaration.requireQualifiedName()
-    check(scope == AppScope::class.requireQualifiedName(), clazz) {
-      "Robots can only be contributed to the AppScope for now. Scope $scope is unsupported."
     }
   }
 

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/processor/ContributesRobotGeneratorTest.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/processor/ContributesRobotGeneratorTest.kt
@@ -50,6 +50,7 @@ class ContributesRobotGeneratorTest {
 
       assertThat(robotComponent.getAnnotation(ContributesTo::class.java).scope)
         .isEqualTo(AppScope::class)
+      assertThat(robotComponent.interfaces.toList()).contains(RobotComponent::class.java)
       assertThat(robotComponent.origin).isEqualTo(testRobot)
 
       with(robotComponent.declaredNonSyntheticMethods.single { it.name == "provideTestRobot" }) {
@@ -320,25 +321,25 @@ class ContributesRobotGeneratorTest {
   }
 
   @Test
-  fun `only the app scope is supported for now`() {
+  fun `a custom scope is supported`() {
     compile(
       """
             package software.ralf.test
 
             import software.ralf.app.platform.inject.robot.ContributesRobot
             import software.ralf.app.platform.robot.Robot
-            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-
             @ContributesRobot(String::class)
             class TestRobot : Robot
             """,
-      exitCode = COMPILATION_ERROR,
+      customScopeComponentInterfaceSource,
     ) {
-      assertThat(messages)
-        .contains(
-          "Robots can only be contributed to the AppScope for now. " +
-            "Scope kotlin.String is unsupported."
-        )
+      val robotComponent = testRobot.component
+
+      assertThat(robotComponent.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(String::class)
+      assertThat(robotComponent.interfaces.toList()).contains(RobotComponent::class.java)
+      assertThat(componentInterface.newComponent<RobotComponent>().robots.keys)
+        .containsOnly(testRobot.kotlin)
     }
   }
 
@@ -356,6 +357,19 @@ class ContributesRobotGeneratorTest {
         @Component
         @MergeComponent(AppScope::class, exclude = [RendererComponent::class])
         @SingleIn(AppScope::class)
+        interface ComponentInterface : ComponentInterfaceMerged
+    """
+
+  @Language("kotlin")
+  private val customScopeComponentInterfaceSource =
+    """
+        package software.ralf.test
+
+        import me.tatarka.inject.annotations.Component
+        import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+
+        @Component
+        @MergeComponent(String::class)
         interface ComponentInterface : ComponentInterfaceMerged
     """
 

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRobotProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRobotProcessor.kt
@@ -25,7 +25,6 @@ import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
-import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.IntoMap
@@ -68,6 +67,7 @@ internal class ContributesRobotProcessor(
 
   private val robotClassName = ClassName("software.ralf.app.platform.robot", "Robot")
   private val robotFqName = robotClassName.canonicalName
+  private val robotGraphClassName = ClassName("software.ralf.app.platform.robot", "RobotGraph")
 
   private val robotKey = RobotKey::class.asClassName()
 
@@ -79,7 +79,6 @@ internal class ContributesRobotProcessor(
         checkIsPublic(it)
         checkNotSingleton(it)
         checkSuperType(it)
-        checkAppScope(it)
         checkSingleConstructorOrInject(it)
       }
       .forEach { generateGraph(it) }
@@ -96,6 +95,7 @@ internal class ContributesRobotProcessor(
         .addType(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
+            .addSuperinterface(robotGraphClassName)
             .addMetroOriginAnnotation(clazz)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
@@ -155,13 +155,6 @@ internal class ContributesRobotProcessor(
     check(extendsRobot, clazz) {
       "In order to use @ContributesRobot, ${clazz.simpleName.asString()} must " +
         "implement $robotFqName."
-    }
-  }
-
-  private fun checkAppScope(clazz: KSClassDeclaration) {
-    val scope = clazz.scope().type.declaration.requireQualifiedName()
-    check(scope == AppScope::class.requireQualifiedName(), clazz) {
-      "Robots can only be contributed to the AppScope for now. Scope $scope is unsupported."
     }
   }
 

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
@@ -28,7 +28,7 @@ import software.ralf.app.platform.ksp.isAnnotatedWith
 import software.ralf.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.ralf.app.platform.renderer.metro.RobotKey
 import software.ralf.app.platform.robot.Robot
-import software.ralf.test.TestRobotGraph
+import software.ralf.app.platform.robot.RobotGraph
 
 class ContributesRobotGeneratorTest {
 
@@ -51,6 +51,7 @@ class ContributesRobotGeneratorTest {
 
       assertThat(robotGraph.getAnnotation(ContributesTo::class.java).scope)
         .isEqualTo(AppScope::class)
+      assertThat(robotGraph.interfaces.toList()).contains(RobotGraph::class.java)
 
       with(robotGraph.declaredNonSyntheticMethods.single { it.name == "provideTestRobot" }) {
         assertThat(parameters).isEmpty()
@@ -67,7 +68,7 @@ class ContributesRobotGeneratorTest {
         assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
       }
 
-      assertThat(graphInterface.newMetroGraph<TestRobotGraph>().robots.keys)
+      assertThat(graphInterface.newMetroGraph<RobotGraph>().robots.keys)
         .containsOnly(testRobot.kotlin)
     }
   }
@@ -107,7 +108,7 @@ class ContributesRobotGeneratorTest {
         assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
       }
 
-      assertThat(graphInterface.newMetroGraph<TestRobotGraph>().robots.keys)
+      assertThat(graphInterface.newMetroGraph<RobotGraph>().robots.keys)
         .containsOnly(testRobot.kotlin)
     }
   }
@@ -140,7 +141,7 @@ class ContributesRobotGeneratorTest {
         )
         .isNull()
 
-      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      val robot = graphInterface.newMetroGraph<RobotGraph>().robots[testRobot.kotlin]!!()
       assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
     }
   }
@@ -175,7 +176,7 @@ class ContributesRobotGeneratorTest {
         )
         .isNull()
 
-      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      val robot = graphInterface.newMetroGraph<RobotGraph>().robots[testRobot.kotlin]!!()
       assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency injected")
     }
   }
@@ -234,7 +235,7 @@ class ContributesRobotGeneratorTest {
         assertThat(this).isAnnotatedWith(Provides::class)
       }
 
-      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      val robot = graphInterface.newMetroGraph<RobotGraph>().robots[testRobot.kotlin]!!()
       assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
     }
   }
@@ -315,25 +316,25 @@ class ContributesRobotGeneratorTest {
   }
 
   @Test
-  fun `only the app scope is supported for now`() {
+  fun `a custom scope is supported`() {
     compile(
       """
       package software.ralf.test
 
       import software.ralf.app.platform.inject.robot.ContributesRobot
       import software.ralf.app.platform.robot.Robot
-      import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 
       @ContributesRobot(String::class)
       class TestRobot : Robot
-              """,
-      exitCode = COMPILATION_ERROR,
+      """,
+      customScopeGraphInterfaceSource,
     ) {
-      assertThat(messages)
-        .contains(
-          "Robots can only be contributed to the AppScope for now. " +
-            "Scope kotlin.String is unsupported."
-        )
+      val robotGraph = testRobot.graph
+
+      assertThat(robotGraph.getAnnotation(ContributesTo::class.java).scope).isEqualTo(String::class)
+      assertThat(robotGraph.interfaces.toList()).contains(RobotGraph::class.java)
+      assertThat(graphInterface.newMetroGraph<RobotGraph>().robots.keys)
+        .containsOnly(testRobot.kotlin)
     }
   }
 
@@ -349,7 +350,7 @@ class ContributesRobotGeneratorTest {
 
         @DependencyGraph(AppScope::class)
         @SingleIn(AppScope::class)
-        interface GraphInterface : TestRobotGraph {
+        interface GraphInterface {
             companion object {
                 fun create(): GraphInterface = createGraph<GraphInterface>()
             }
@@ -369,9 +370,25 @@ class ContributesRobotGeneratorTest {
 
         @DependencyGraph(AppScope::class)
         @SingleIn(AppScope::class)
-        interface GraphInterface : TestRobotGraph {
+        interface GraphInterface {
             @Provides fun provideString(): String = "dependency"
 
+            companion object {
+                fun create(): GraphInterface = createGraph<GraphInterface>()
+            }
+        }
+    """
+
+  @Language("kotlin")
+  private val customScopeGraphInterfaceSource =
+    """
+        package software.ralf.test
+
+        import dev.zacsweers.metro.createGraph
+        import dev.zacsweers.metro.DependencyGraph
+
+        @DependencyGraph(String::class)
+        interface GraphInterface {
             companion object {
                 fun create(): GraphInterface = createGraph<GraphInterface>()
             }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/test/TestRobotGraph.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/test/TestRobotGraph.kt
@@ -1,8 +1,0 @@
-package software.ralf.test
-
-import kotlin.reflect.KClass
-import software.ralf.app.platform.robot.Robot
-
-interface TestRobotGraph {
-  val robots: Map<KClass<*>, () -> Robot>
-}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/ClassIds.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/ClassIds.kt
@@ -61,6 +61,9 @@ internal object ClassIds {
 
   val ROBOT = ClassId(FqName("software.ralf.app.platform.robot"), Name.identifier("Robot"))
 
+  val ROBOT_GRAPH =
+    ClassId(FqName("software.ralf.app.platform.robot"), Name.identifier("RobotGraph"))
+
   val ROBOT_KEY =
     ClassId(FqName("software.ralf.app.platform.renderer.metro"), Name.identifier("RobotKey"))
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotChecker.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotChecker.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.name.ClassId
 import software.ralf.app.platform.metro.compiler.ClassIds
 import software.ralf.app.platform.metro.compiler.fir.AppPlatformMetroExtensionsDiagnostics
-import software.ralf.app.platform.metro.compiler.fir.extractScopeClassId
 import software.ralf.app.platform.metro.compiler.fir.hasAnnotation
 import software.ralf.app.platform.metro.compiler.fir.hasTransitiveSupertype
 
@@ -81,17 +80,6 @@ internal object ContributesRobotChecker : FirClassChecker(MppCheckerKind.Common)
           "robot is scoped to the robot() factory function. Remove the @" +
           singletonAnnotation.toAnnotationClassIdSafe(session)?.shortClassName?.asString() +
           " annotation.",
-      )
-    }
-
-    val scopeClassId =
-      extractScopeClassId(classSymbol, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
-    if (scopeClassId != null && scopeClassId != ClassIds.APP_SCOPE) {
-      reporter.reportOn(
-        annotation.source ?: declaration.source,
-        AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_ROBOT_ERROR,
-        "Robots can only be contributed to the AppScope for now. Scope " +
-          "${scopeClassId.asSingleFqName()} is unsupported.",
       )
     }
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotFir.kt
@@ -89,6 +89,9 @@ import software.ralf.app.platform.metro.compiler.fir.resolveTypeRef
  *       fun provideTestRobot(dependency: RobotDependency): TestRobot
  *     }
  *   }
+ *
+ *   @ContributesTo(AppScope::class)
+ *   interface RobotGraphContribution : RobotGraph
  * }
  * ```
  *
@@ -103,14 +106,23 @@ public class ContributesRobotFir(session: FirSession) :
   }
 
   override fun getContributionHints(): List<ContributionHint> {
-    return annotatedRobotClasses().mapNotNull { classSymbol ->
+    return annotatedRobotClasses().flatMap { classSymbol ->
       val scopeClassId =
         extractScopeClassId(classSymbol, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
-          ?: return@mapNotNull null
-      ContributionHint(
-        contributingClassId =
-          classSymbol.classId.createNestedClassId(ContributesRobotIds.NESTED_INTERFACE_NAME),
-        scope = scopeClassId,
+          ?: return@flatMap emptyList()
+      listOf(
+        ContributionHint(
+          contributingClassId =
+            classSymbol.classId.createNestedClassId(ContributesRobotIds.NESTED_INTERFACE_NAME),
+          scope = scopeClassId,
+        ),
+        ContributionHint(
+          contributingClassId =
+            classSymbol.classId.createNestedClassId(
+              ContributesRobotIds.NESTED_ROBOT_GRAPH_INTERFACE_NAME
+            ),
+          scope = scopeClassId,
+        ),
       )
     }
   }
@@ -130,7 +142,10 @@ public class ContributesRobotFir(session: FirSession) :
     return if (
       hasAnnotation(classSymbol, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
     ) {
-      setOf(ContributesRobotIds.NESTED_INTERFACE_NAME)
+      setOf(
+        ContributesRobotIds.NESTED_INTERFACE_NAME,
+        ContributesRobotIds.NESTED_ROBOT_GRAPH_INTERFACE_NAME,
+      )
     } else {
       emptySet()
     }
@@ -152,12 +167,46 @@ public class ContributesRobotFir(session: FirSession) :
       return companion.symbol
     }
 
-    if (name != ContributesRobotIds.NESTED_INTERFACE_NAME) return null
     if (!hasAnnotation(owner, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)) return null
 
     val scopeArg =
       extractScopeArgument(owner, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
         ?: return null
+
+    if (name == ContributesRobotIds.NESTED_ROBOT_GRAPH_INTERFACE_NAME) {
+      val nestedClassId = owner.classId.createNestedClassId(name)
+      val classSymbol = FirRegularClassSymbol(nestedClassId)
+      val contributionClass = buildRegularClass {
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = Keys.ContributesRobotGeneratorKey.origin
+        source = owner.source
+        classKind = ClassKind.INTERFACE
+        scopeProvider = session.kotlinScopeProvider
+        this.name = nestedClassId.shortClassName
+        symbol = classSymbol
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.ABSTRACT,
+            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+          )
+        superTypeRefs += robotGraphType().toFirResolvedTypeRef()
+        annotations +=
+          buildAnnotationCallWithArgument(
+            ClassIds.CONTRIBUTES_TO,
+            Name.identifier("scope"),
+            scopeArg,
+            classSymbol,
+            session,
+          )
+        annotations += buildOriginAnnotation(owner)
+      }
+      return contributionClass.symbol
+    }
+
+    if (name != ContributesRobotIds.NESTED_INTERFACE_NAME) return null
+
     val nestedClassId = owner.classId.createNestedClassId(name)
     val classSymbol = FirRegularClassSymbol(nestedClassId)
 
@@ -455,6 +504,13 @@ public class ContributesRobotFir(session: FirSession) :
   private fun robotType() =
     ConeClassLikeTypeImpl(
       ConeClassLikeLookupTagImpl(ClassIds.ROBOT),
+      emptyArray(),
+      isMarkedNullable = false,
+    )
+
+  private fun robotGraphType() =
+    ConeClassLikeTypeImpl(
+      ConeClassLikeLookupTagImpl(ClassIds.ROBOT_GRAPH),
       emptyArray(),
       isMarkedNullable = false,
     )

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotIds.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotIds.kt
@@ -10,6 +10,7 @@ internal object ContributesRobotIds {
   val CONTRIBUTES_ROBOT_CLASS_ID = ClassIds.CONTRIBUTES_ROBOT
   val CONTRIBUTES_ROBOT_FQ_NAME = FqName("software.ralf.app.platform.inject.robot.ContributesRobot")
   val NESTED_INTERFACE_NAME: Name = Name.identifier("RobotContribution")
+  val NESTED_ROBOT_GRAPH_INTERFACE_NAME: Name = Name.identifier("RobotGraphContribution")
 
   val PREDICATE = LookupPredicate.create { annotated(CONTRIBUTES_ROBOT_FQ_NAME) }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotMetroExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotMetroExtension.kt
@@ -36,29 +36,43 @@ public class ContributesRobotMetroExtension(private val session: FirSession) :
     scopeClassId: ClassId,
     typeResolverFactory: MetroFirTypeResolver.Factory,
   ): List<MetroContributionExtension.Contribution> {
-    return annotatedClasses.mapNotNull { parentSymbol ->
+    return annotatedClasses.flatMap { parentSymbol ->
       val annotationScopeClassId =
         extractScopeClassId(parentSymbol, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
-          ?: return@mapNotNull null
-      if (annotationScopeClassId != scopeClassId) return@mapNotNull null
+          ?: return@flatMap emptyList()
+      if (annotationScopeClassId != scopeClassId) return@flatMap emptyList()
 
       val contributionInterfaceClassId =
         parentSymbol.classId.createNestedClassId(ContributesRobotIds.NESTED_INTERFACE_NAME)
       val contributionSymbol =
         session.symbolProvider.getClassLikeSymbolByClassId(contributionInterfaceClassId)
-          as? FirRegularClassSymbol ?: return@mapNotNull null
+          as? FirRegularClassSymbol ?: return@flatMap emptyList()
       val scope = contributionSymbol.declaredMemberScope(session, memberRequiredPhase = null)
       val metroContributionName =
         scope.getClassifierNames().firstOrNull { it.identifier.startsWith("MetroContributionTo") }
-          ?: return@mapNotNull null
+          ?: return@flatMap emptyList()
       val metroContributionSymbol =
         scope.getSingleClassifier(metroContributionName) as? FirRegularClassSymbol
-          ?: return@mapNotNull null
+          ?: return@flatMap emptyList()
+      val robotGraphContributionClassId =
+        parentSymbol.classId.createNestedClassId(
+          ContributesRobotIds.NESTED_ROBOT_GRAPH_INTERFACE_NAME
+        )
+      val robotGraphContributionSymbol =
+        session.symbolProvider.getClassLikeSymbolByClassId(robotGraphContributionClassId)
+          as? FirRegularClassSymbol ?: return@flatMap emptyList()
 
-      MetroContributionExtension.Contribution(
-        supertype = metroContributionSymbol.defaultType(),
-        replaces = emptyList(),
-        originClassId = parentSymbol.classId,
+      listOf(
+        MetroContributionExtension.Contribution(
+          supertype = metroContributionSymbol.defaultType(),
+          replaces = emptyList(),
+          originClassId = parentSymbol.classId,
+        ),
+        MetroContributionExtension.Contribution(
+          supertype = robotGraphContributionSymbol.defaultType(),
+          replaces = emptyList(),
+          originClassId = parentSymbol.classId,
+        ),
       )
     }
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/ralf/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/ralf/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
@@ -89,12 +89,6 @@ public class FirDiagnosticTestGenerated extends AbstractFirDiagnosticTest {
     }
 
     @Test
-    @TestMetadata("onlyAppScopeSupported.kt")
-    public void testOnlyAppScopeSupported() {
-      run("onlyAppScopeSupported.kt");
-    }
-
-    @Test
     @TestMetadata("robotMustNotBeSingleton.kt")
     public void testRobotMustNotBeSingleton() {
       run("robotMustNotBeSingleton.kt");

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
@@ -15,7 +15,7 @@ class TestRobot(
 ) : Robot
 
 @DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph {
+interface MyGraph {
   @Provides fun robotDependency(): RobotDependency = RobotDependency()
 }
 
@@ -38,7 +38,7 @@ fun box(): String {
     return "FAIL: expected provider on RobotContribution companion"
   }
 
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/defaultConstructorRobot.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/defaultConstructorRobot.kt
@@ -4,14 +4,16 @@ import software.ralf.app.platform.inject.robot.ContributesRobot
 import software.ralf.app.platform.robot.Robot
 import software.ralf.app.platform.robot.RobotGraph
 
-@ContributesRobot(AppScope::class)
+abstract class TestScope private constructor()
+
+@ContributesRobot(TestScope::class)
 class TestRobot : Robot
 
-@DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph
+@DependencyGraph(TestScope::class)
+interface MyGraph
 
 fun box(): String {
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/indirectSupertype.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/indirectSupertype.kt
@@ -13,10 +13,10 @@ abstract class BaseRobot2 : BaseRobot1
 class TestRobot : BaseRobot2()
 
 @DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph
+interface MyGraph
 
 fun box(): String {
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectClassSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectClassSkipsProvider.kt
@@ -16,7 +16,7 @@ class TestRobot(
 ) : Robot
 
 @DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph
+interface MyGraph
 
 fun box(): String {
   val provider =
@@ -27,7 +27,7 @@ fun box(): String {
     return "FAIL: expected generated provider to be skipped"
   }
 
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectConstructorRobot.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectConstructorRobot.kt
@@ -16,10 +16,10 @@ class TestRobot(
 ) : Robot
 
 @DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph
+interface MyGraph
 
 fun box(): String {
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectSecondaryConstructorSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectSecondaryConstructorSkipsProvider.kt
@@ -18,7 +18,7 @@ class TestRobot private constructor(
 }
 
 @DependencyGraph(AppScope::class)
-interface MyGraph : RobotGraph
+interface MyGraph
 
 fun box(): String {
   val provider =
@@ -29,7 +29,7 @@ fun box(): String {
     return "FAIL: expected generated provider to be skipped"
   }
 
-  val graph = createGraph<MyGraph>()
+  val graph = createGraph<MyGraph>() as RobotGraph
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classMustImplementRobot.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classMustImplementRobot.fir.diag.txt
@@ -1,3 +1,1 @@
 /classMustImplementRobot.kt:(144,174): error: In order to use @ContributesRobot, MissingRobot must implement software.ralf.app.platform.robot.Robot.
-
-/classMustImplementRobot.kt:(144,174): error: Robots can only be contributed to the AppScope for now. Scope kotlin.Unit is unsupported.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classMustImplementRobot.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classMustImplementRobot.kt
@@ -3,5 +3,5 @@ package com.test
 
 import software.ralf.app.platform.inject.robot.ContributesRobot
 
-<!CONTRIBUTES_ROBOT_ERROR, CONTRIBUTES_ROBOT_ERROR!>@ContributesRobot(Unit::class)<!>
+<!CONTRIBUTES_ROBOT_ERROR!>@ContributesRobot(Unit::class)<!>
 class MissingRobot

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/onlyAppScopeSupported.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/onlyAppScopeSupported.fir.diag.txt
@@ -1,1 +1,0 @@
-/onlyAppScopeSupported.kt:(190,222): error: Robots can only be contributed to the AppScope for now. Scope kotlin.String is unsupported.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/onlyAppScopeSupported.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/onlyAppScopeSupported.kt
@@ -1,8 +1,0 @@
-// RENDER_DIAGNOSTICS_FULL_TEXT
-package com.test
-
-import software.ralf.app.platform.inject.robot.ContributesRobot
-import software.ralf.app.platform.robot.Robot
-
-<!CONTRIBUTES_ROBOT_ERROR!>@ContributesRobot(String::class)<!>
-class TestRobot : Robot

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
@@ -61,8 +61,18 @@ FILE: constructorParametersWithoutInject.kt
 
         }
 
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|) [evaluated = <getClass>(Q|dev/zacsweers/metro/AppScope|)]) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotGraphContribution : R|software/ralf/app/platform/robot/RobotGraph| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeocf15 : R|com/test/TestRobot.RobotGraphContribution| {
+            }
+
+        }
+
     }
 FILE: metro/hints/comTestTestRobotRobotContributionDev_zacsweers_metro_AppScope.kt
     package metro.hints
 
     @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotContribution|): R|kotlin/Unit|
+FILE: metro/hints/comTestTestRobotRobotGraphContributionDev_zacsweers_metro_AppScope.kt
+    package metro.hints
+
+    @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotGraphContribution|): R|kotlin/Unit|

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobot.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobot.fir.txt
@@ -40,8 +40,18 @@ FILE: defaultConstructorRobot.kt
 
         }
 
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|) [evaluated = <getClass>(Q|dev/zacsweers/metro/AppScope|)]) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotGraphContribution : R|software/ralf/app/platform/robot/RobotGraph| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeocf15 : R|com/test/TestRobot.RobotGraphContribution| {
+            }
+
+        }
+
     }
 FILE: metro/hints/comTestTestRobotRobotContributionDev_zacsweers_metro_AppScope.kt
     package metro.hints
 
     @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotContribution|): R|kotlin/Unit|
+FILE: metro/hints/comTestTestRobotRobotGraphContributionDev_zacsweers_metro_AppScope.kt
+    package metro.hints
+
+    @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotGraphContribution|): R|kotlin/Unit|

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.kt.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.kt.txt
@@ -86,6 +86,16 @@ class TestRobot : Robot {
 
   }
 
+  @ContributesTo(scope = AppScope::class)
+  @Origin(value = TestRobot::class)
+  interface RobotGraphContribution : RobotGraph {
+    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+    @MetroContribution(scope = AppScope::class)
+    interface MetroContributionToDevzacsweersmetroappScopeocf15 : RobotGraphContribution {
+    }
+
+  }
+
   constructor() /* primary */ {
     super/*Any*/()
     /* <init>() */
@@ -99,6 +109,14 @@ package metro.hints
 
 @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
 fun dev_zacsweers_metro_AppScope(contributed: RobotContribution) {
+  return error(message = "Never called")
+}
+
+// FILE: comTestTestRobotRobotGraphContributionDev_zacsweers_metro_AppScope.kt
+package metro.hints
+
+@Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+fun dev_zacsweers_metro_AppScope(contributed: RobotGraphContribution) {
   return error(message = "Never called")
 }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
@@ -40,8 +40,18 @@ FILE: defaultConstructorRobotIr.kt
 
         }
 
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|) [evaluated = <getClass>(Q|dev/zacsweers/metro/AppScope|)]) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotGraphContribution : R|software/ralf/app/platform/robot/RobotGraph| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeocf15 : R|com/test/TestRobot.RobotGraphContribution| {
+            }
+
+        }
+
     }
 FILE: metro/hints/comTestTestRobotRobotContributionDev_zacsweers_metro_AppScope.kt
     package metro.hints
 
     @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotContribution|): R|kotlin/Unit|
+FILE: metro/hints/comTestTestRobotRobotGraphContributionDev_zacsweers_metro_AppScope.kt
+    package metro.hints
+
+    @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun dev_zacsweers_metro_AppScope(contributed: R|com/test/TestRobot.RobotGraphContribution|): R|kotlin/Unit|

--- a/robot/public/api/android/public.api
+++ b/robot/public/api/android/public.api
@@ -38,6 +38,7 @@ public abstract interface class software/ralf/app/platform/robot/RobotGraph$Metr
 }
 
 public final class software/ralf/app/platform/robot/RobotKt {
+	public static final fun findRobotFactory (Lsoftware/ralf/app/platform/scope/Scope;Lkotlin/reflect/KClass;)Lkotlin/jvm/functions/Function0;
 	public static final fun getAllRobots (Lsoftware/ralf/app/platform/scope/Scope;)Ljava/util/Map;
 }
 

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -22,6 +22,7 @@ public abstract interface class software/ralf/app/platform/robot/RobotGraph$Metr
 }
 
 public final class software/ralf/app/platform/robot/RobotKt {
+	public static final fun findRobotFactory (Lsoftware/ralf/app/platform/scope/Scope;Lkotlin/reflect/KClass;)Lkotlin/jvm/functions/Function0;
 	public static final fun getAllRobots (Lsoftware/ralf/app/platform/scope/Scope;)Ljava/util/Map;
 }
 

--- a/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/Robot.kt
+++ b/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/Robot.kt
@@ -79,14 +79,15 @@ public interface Robot {
  * }
  * ```
  *
- * [rootScope] refers to the application scope, which provides [RobotComponent]. Usually, the
- * parameter doesn't need to be changed and the default value can be used.
+ * [rootScope] refers to the application scope. The scope and all of its children are searched for
+ * the contributed robot. Usually, the parameter doesn't need to be changed and the default value
+ * can be used.
  */
 public inline fun <reified T : Robot> robot(
   rootScope: Scope = software.ralf.app.platform.robot.internal.rootScope,
   noinline block: T.() -> Unit,
 ) {
-  val robot = rootScope.allRobots[T::class]?.invoke() as? T
+  val robot = rootScope.findRobotFactory(T::class)?.invoke() as? T
 
   checkNotNull(robot) {
     "Could not find Robot of type ${T::class}. Did you forget to add the @ContributesRobot " +
@@ -98,6 +99,34 @@ public inline fun <reified T : Robot> robot(
   } finally {
     robot.close()
   }
+}
+
+@PublishedApi
+internal fun Scope.findRobotFactory(robotType: KClass<*>): (() -> Robot)? {
+  var match: (() -> Robot)? = null
+  var matchingScope: Scope? = null
+
+  fun Scope.findRobot(inheritedRobotTypes: Set<KClass<*>>) {
+    if (isDestroyed()) return
+
+    val robots = allRobots
+    if (robotType !in inheritedRobotTypes) {
+      robots[robotType]?.let { robotFactory ->
+        check(match == null) {
+          "Found Robot of type $robotType in multiple scopes: " +
+            "${matchingScope?.name} and $name."
+        }
+        match = robotFactory
+        matchingScope = this
+      }
+    }
+
+    val visibleRobotTypes = inheritedRobotTypes + robots.keys
+    children().forEach { childScope -> childScope.findRobot(visibleRobotTypes) }
+  }
+
+  findRobot(emptySet())
+  return match
 }
 
 @PublishedApi

--- a/robot/public/src/commonTest/kotlin/software/ralf/app/platform/robot/RobotTest.kt
+++ b/robot/public/src/commonTest/kotlin/software/ralf/app/platform/robot/RobotTest.kt
@@ -112,6 +112,67 @@ class RobotTest {
     assertThat(metroRobot).isNotNull()
   }
 
+  @Test
+  fun `a robot is found in a child scope`() {
+    val rootScope = rootScope()
+    rootScope.buildChild("child") { addMetroDependencyGraph(Graph(ChildTestRobot())) }
+
+    var childRobot: ChildTestRobot? = null
+    robot<ChildTestRobot>(rootScope) { childRobot = this }
+
+    assertThat(childRobot).isNotNull()
+  }
+
+  @Test
+  fun `robots inherited from a parent scope are not ambiguous`() {
+    val rootRobot = MetroTestRobot()
+    val rootScope = rootScope(kiRobot = null, metroRobot = rootRobot)
+    val childRobot = ChildTestRobot()
+    val childScope =
+      rootScope.buildChild("child") {
+        addMetroDependencyGraph(Graph(rootRobot, childRobot))
+      }
+    childScope.buildChild("grandchild") {
+      addMetroDependencyGraph(Graph(rootRobot, childRobot))
+    }
+
+    var foundRootRobot: MetroTestRobot? = null
+    robot<MetroTestRobot>(rootScope) { foundRootRobot = this }
+
+    var foundChildRobot: ChildTestRobot? = null
+    robot<ChildTestRobot>(rootScope) { foundChildRobot = this }
+
+    assertThat(foundRootRobot).isNotNull()
+    assertThat(foundChildRobot).isNotNull()
+  }
+
+  @Test
+  fun `the same robot in sibling scopes is ambiguous`() {
+    val rootScope = rootScope(kiRobot = null, metroRobot = null)
+    rootScope.buildChild("child-1") { addMetroDependencyGraph(Graph(ChildTestRobot())) }
+    rootScope.buildChild("child-2") { addMetroDependencyGraph(Graph(ChildTestRobot())) }
+
+    val exception = assertFailsWith<IllegalStateException> { robot<ChildTestRobot>(rootScope) {} }
+
+    val message =
+      exception.message?.replace("RobotTest\$ChildTestRobot", "RobotTest.ChildTestRobot").toString()
+    assertThat(message)
+      .contains(
+        "Found Robot of type class software.ralf.app.platform.robot.RobotTest.ChildTestRobot"
+      )
+    assertThat(message).contains("child-1 and child-2")
+  }
+
+  @Test
+  fun `destroyed child scopes are not searched`() {
+    val rootScope = rootScope(kiRobot = null, metroRobot = null)
+    val childScope =
+      rootScope.buildChild("child") { addMetroDependencyGraph(Graph(ChildTestRobot())) }
+    childScope.destroy()
+
+    assertFailsWith<IllegalStateException> { robot<ChildTestRobot>(rootScope) {} }
+  }
+
   private fun rootScope(
     kiRobot: Robot? = KiTestRobot(),
     metroRobot: Robot? = MetroTestRobot(),
@@ -153,4 +214,6 @@ class RobotTest {
       closeCalled = true
     }
   }
+
+  private class ChildTestRobot : Robot
 }

--- a/sample/user/impl-robots/src/commonMain/kotlin/software/ralf/app/platform/sample/user/UserPageRobot.kt
+++ b/sample/user/impl-robots/src/commonMain/kotlin/software/ralf/app/platform/sample/user/UserPageRobot.kt
@@ -4,19 +4,17 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import dev.zacsweers.metro.AppScope
 import software.ralf.app.platform.inject.robot.ContributesRobot
 import software.ralf.app.platform.robot.ComposeRobot
 
 /**
  * A test robot to verify interactions with the user page screen written with Compose Multiplatform.
  *
- * This robot injects other dependencies from the object graph, e.g. this is helpful to query
- * further data or change behavior of classes. Robots are not exclusive to verifying UI and UI
- * interactions.
+ * This robot injects the [User] from the user-scoped object graph. Robots are not exclusive to
+ * verifying UI and UI interactions and can use dependencies from their contributed scope.
  */
-@ContributesRobot(AppScope::class)
-class UserPageRobot(private val userManager: UserManager) : ComposeRobot() {
+@ContributesRobot(UserScope::class)
+class UserPageRobot(private val user: User) : ComposeRobot() {
 
   private val userIdTextNode
     get() = compose.onNodeWithTag("userIdText")
@@ -25,10 +23,10 @@ class UserPageRobot(private val userManager: UserManager) : ComposeRobot() {
     get() = compose.onNodeWithTag("profilePicture")
 
   /**
-   * Verify that the user ID is displayed. The [userId] can be changed, but uses by default the ID
-   * of the logged in user if present.
+   * Verify that the user ID is displayed. The [userId] can be changed, but defaults to the ID of
+   * the user associated with this robot's scope.
    */
-  fun seeUserId(userId: Long = userManager.user.value?.userId ?: -1L) {
+  fun seeUserId(userId: Long = user.userId) {
     userIdTextNode.assertIsDisplayed()
     userIdTextNode.assertTextEquals("User: $userId")
   }


### PR DESCRIPTION
**Support robots in child scopes:**
Generate robot graph entry points for every contributed scope and search the scope tree during lookup so scoped robots can inject scope-local dependencies without requiring tests to pass a scope explicitly.

Reject ambiguous sibling matches instead of selecting an arbitrary scope instance.

**Exercise scoped robots in the sample app:**
Contribute `UserPageRobot` to `UserScope` and inject its graph-provided `User` so the existing UI tests demonstrate root lookup of a child-scoped robot and child-scope dependency injection.