### PR TITLE
Make Detekt compatible with isolated projects

### DIFF
--- a/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/Detekt.kt
+++ b/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/Detekt.kt
@@ -40,7 +40,7 @@ internal fun Project.configureDetekt() {
     // This produces baselines named "detekt-baseline.xml"
     baseline.set(file("detekt/detekt-baseline.xml"))
     // Config overrides
-    config.from(rootProject.file("gradle/detekt-config.yml"))
+    config.from(rootDir.resolve("gradle/detekt-config.yml"))
     buildUponDefaultConfig.set(true)
   }
 


### PR DESCRIPTION
Resolve the shared configuration through `rootDir` so project configuration no longer reaches into the root project’s mutable `Project` API. This removes App Platform’s own isolated-project violations while preserving the existing Detekt configuration.