### PR TITLE
Upgrade App Platform in blueprints

### DIFF
--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Build Desktop binary
-        run: ./gradlew :app:desktopMainClasses
+        run: ./gradlew :app:desktop:desktopMainClasses

--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -34,7 +34,7 @@ jobs:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           select-xcode-26: "true"
       - name: Build iOS Framework
-        run: ./gradlew :app:linkDebugFrameworkIosSimulatorArm64
+        run: ./gradlew :app-framework:impl:linkDebugFrameworkIosSimulatorArm64
 
   build-wasm-starter-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Build WASM binary
-        run: ./gradlew :app:wasmJsBrowserDistribution
+        run: ./gradlew :app:web:wasmJsBrowserDistribution
 
   build-android-starter-app:
     runs-on: ubuntu-latest

--- a/blueprints/list-detail/gradle/libs.versions.toml
+++ b/blueprints/list-detail/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ androidx-test-junit = "1.3.0"
 androidx-test-orchestrator = "1.6.1"
 androidx-test-rules = "1.7.0"
 androidx-test-runner = "1.7.0"
-app-platform = "0.1.1"
+app-platform = "0.1.3"
 assertk = "0.28.1"
 compose-android = "1.11.4"
 compose-material-icons = "1.7.3"
@@ -20,7 +20,7 @@ detekt = "2.0.0-alpha.5"
 jvm-buildsrc = "21"
 jvm-target = "11"
 kotlin = "2.4.10"
-metro = "1.3.2"
+metro = "1.4.2"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/blueprints/starter/gradle/libs.versions.toml
+++ b/blueprints/starter/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 assertk = "0.28.1"
-app-platform = "0.1.1"
+app-platform = "0.1.3"
 agp = "9.3.1"
 android-compileSdk = "37"
 android-minSdk = "23"
@@ -11,7 +11,7 @@ compose-material3 = "1.9.0"
 compose-multiplatform = "1.11.1"
 coroutines = "1.11.0"
 kotlin = "2.4.10"
-metro = "1.3.2"
+metro = "1.4.2"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }


### PR DESCRIPTION
Keep both standalone blueprints on the latest published App Platform release and align Metro with the generated bindings required by `0.1.3`, avoiding compiler ABI failures in blueprint builds.