### PR TITLE
Upgrade Compose Multiplatform to 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Upgrade KSP to `2.3.11`.
+- Upgrade Compose Multiplatform to `1.12.0`.
 
 ### Deprecated
 

--- a/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/Platform.kt
+++ b/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/Platform.kt
@@ -152,6 +152,10 @@ internal sealed interface Platform {
     override fun configurePlatform() {
       @Suppress("OPT_IN_USAGE")
       project.kmpExtension.wasmJs { browser { outputModuleName.set(project.safePathString) } }
+
+      project.plugins.withId(Plugins.COMPOSE_MULTIPLATFORM) {
+        @Suppress("OPT_IN_USAGE") project.kmpExtension.wasmJs { binaries.executable() }
+      }
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ build-config = "6.0.10"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#kotlin-compatibility
 # https://mvnrepository.com/artifact/org.jetbrains.compose/compose-gradle-plugin
 # https://github.com/JetBrains/compose-multiplatform/releases
-compose-multiplatform = "1.11.1"
+compose-multiplatform = "1.12.0"
 coroutines = "1.11.0"
 detekt = "2.0.0-alpha.6"
 graphviz-java = "0.18.1"


### PR DESCRIPTION
Adopt the latest stable Compose fixes across Android, iOS, desktop, and Wasm, and declare Wasm executables when Compose UI is applied so the stricter 1.12 test configuration can load Skiko in browser tests.