### PR TITLE
Make Molecule presenter dispatcher test deterministic

### DIFF
--- a/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,0 +1,31 @@
+package software.ralf.app.platform.internal
+
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+
+actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
+
+private class JvmMarkedDispatcher : MarkedDispatcher {
+  private val currentThreadMarker = ThreadLocal<Boolean>()
+  private val executor =
+    Executors.newSingleThreadExecutor { runnable ->
+      Thread {
+        currentThreadMarker.set(true)
+        try {
+          runnable.run()
+        } finally {
+          currentThreadMarker.remove()
+        }
+      }
+    }
+  private val closeableDispatcher = executor.asCoroutineDispatcher()
+
+  override val dispatcher: CoroutineDispatcher = closeableDispatcher
+
+  override fun isCurrentThreadMarked(): Boolean = currentThreadMarker.get() == true
+
+  override fun close() {
+    closeableDispatcher.close()
+  }
+}

--- a/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -8,17 +8,16 @@ actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
 
 private class JvmMarkedDispatcher : MarkedDispatcher {
   private val currentThreadMarker = ThreadLocal<Boolean>()
-  private val executor =
-    Executors.newSingleThreadExecutor { runnable ->
-      Thread {
-        currentThreadMarker.set(true)
-        try {
-          runnable.run()
-        } finally {
-          currentThreadMarker.remove()
-        }
+  private val executor = Executors.newSingleThreadExecutor { runnable ->
+    Thread {
+      currentThreadMarker.set(true)
+      try {
+        runnable.run()
+      } finally {
+        currentThreadMarker.remove()
       }
     }
+  }
   private val closeableDispatcher = executor.asCoroutineDispatcher()
 
   override val dispatcher: CoroutineDispatcher = closeableDispatcher

--- a/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -4,6 +4,7 @@ import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 
+/** Creates a marked dispatcher backed by a dedicated JVM thread. */
 actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
 
 private class JvmMarkedDispatcher : MarkedDispatcher {

--- a/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/Thread.kt
+++ b/internal/testing/src/androidMain/kotlin/software/ralf/app/platform/internal/Thread.kt
@@ -1,5 +1,0 @@
-package software.ralf.app.platform.internal
-
-/** Provides the name of the current thread this is called on. */
-actual val currentThreadName: String
-  get() = Thread.currentThread().name

--- a/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,0 +1,13 @@
+package software.ralf.app.platform.internal
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+interface MarkedDispatcher {
+  val dispatcher: CoroutineDispatcher
+
+  fun isCurrentThreadMarked(): Boolean
+
+  fun close()
+}
+
+expect fun createMarkedDispatcher(): MarkedDispatcher

--- a/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -2,12 +2,17 @@ package software.ralf.app.platform.internal
 
 import kotlinx.coroutines.CoroutineDispatcher
 
+/** A closeable dispatcher that reports whether code is running on its managed thread. */
 interface MarkedDispatcher {
+  /** The dispatcher whose work is marked while it runs. */
   val dispatcher: CoroutineDispatcher
 
+  /** Returns whether the current call is running as work dispatched through [dispatcher]. */
   fun isCurrentThreadMarked(): Boolean
 
+  /** Releases the resources owned by [dispatcher]. */
   fun close()
 }
 
+/** Creates a dispatcher for JVM-only tests that distinguish inline from dispatched work. */
 expect fun createMarkedDispatcher(): MarkedDispatcher

--- a/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/Thread.kt
+++ b/internal/testing/src/commonMain/kotlin/software/ralf/app/platform/internal/Thread.kt
@@ -1,4 +1,0 @@
-package software.ralf.app.platform.internal
-
-/** Provides the name of the current thread this is called on. */
-expect val currentThreadName: String

--- a/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,0 +1,31 @@
+package software.ralf.app.platform.internal
+
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+
+actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
+
+private class JvmMarkedDispatcher : MarkedDispatcher {
+  private val currentThreadMarker = ThreadLocal<Boolean>()
+  private val executor =
+    Executors.newSingleThreadExecutor { runnable ->
+      Thread {
+        currentThreadMarker.set(true)
+        try {
+          runnable.run()
+        } finally {
+          currentThreadMarker.remove()
+        }
+      }
+    }
+  private val closeableDispatcher = executor.asCoroutineDispatcher()
+
+  override val dispatcher: CoroutineDispatcher = closeableDispatcher
+
+  override fun isCurrentThreadMarked(): Boolean = currentThreadMarker.get() == true
+
+  override fun close() {
+    closeableDispatcher.close()
+  }
+}

--- a/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -8,17 +8,16 @@ actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
 
 private class JvmMarkedDispatcher : MarkedDispatcher {
   private val currentThreadMarker = ThreadLocal<Boolean>()
-  private val executor =
-    Executors.newSingleThreadExecutor { runnable ->
-      Thread {
-        currentThreadMarker.set(true)
-        try {
-          runnable.run()
-        } finally {
-          currentThreadMarker.remove()
-        }
+  private val executor = Executors.newSingleThreadExecutor { runnable ->
+    Thread {
+      currentThreadMarker.set(true)
+      try {
+        runnable.run()
+      } finally {
+        currentThreadMarker.remove()
       }
     }
+  }
   private val closeableDispatcher = executor.asCoroutineDispatcher()
 
   override val dispatcher: CoroutineDispatcher = closeableDispatcher

--- a/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -4,6 +4,7 @@ import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 
+/** Creates a marked dispatcher backed by a dedicated JVM thread. */
 actual fun createMarkedDispatcher(): MarkedDispatcher = JvmMarkedDispatcher()
 
 private class JvmMarkedDispatcher : MarkedDispatcher {

--- a/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/Thread.kt
+++ b/internal/testing/src/desktopMain/kotlin/software/ralf/app/platform/internal/Thread.kt
@@ -1,5 +1,0 @@
-package software.ralf.app.platform.internal
-
-/** Provides the name of the current thread this is called on. */
-actual val currentThreadName: String
-  get() = Thread.currentThread().name

--- a/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,0 +1,3 @@
+package software.ralf.app.platform.internal
+
+actual fun createMarkedDispatcher(): MarkedDispatcher = throw NotImplementedError()

--- a/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,3 +1,4 @@
 package software.ralf.app.platform.internal
 
+/** This JVM-only test helper is unavailable on native targets. */
 actual fun createMarkedDispatcher(): MarkedDispatcher = throw NotImplementedError()

--- a/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/Thread.kt
+++ b/internal/testing/src/nativeMain/kotlin/software/ralf/app/platform/internal/Thread.kt
@@ -1,4 +1,0 @@
-package software.ralf.app.platform.internal
-
-/** Provides the name of the current thread this is called on. */
-actual val currentThreadName: String = throw NotImplementedError()

--- a/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,0 +1,3 @@
+package software.ralf.app.platform.internal
+
+actual fun createMarkedDispatcher(): MarkedDispatcher = throw NotImplementedError()

--- a/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
+++ b/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/MarkedDispatcher.kt
@@ -1,3 +1,4 @@
 package software.ralf.app.platform.internal
 
+/** This JVM-only test helper is unavailable on Wasm targets. */
 actual fun createMarkedDispatcher(): MarkedDispatcher = throw NotImplementedError()

--- a/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/Thread.kt
+++ b/internal/testing/src/wasmJsMain/kotlin/software/ralf/app/platform/internal/Thread.kt
@@ -1,4 +1,0 @@
-package software.ralf.app.platform.internal
-
-/** Provides the name of the current thread this is called on. */
-actual val currentThreadName: String = throw NotImplementedError()

--- a/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
@@ -5,11 +5,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import app.cash.molecule.RecompositionMode
 import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
-import assertk.assertions.startsWith
+import assertk.assertions.isTrue
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CoroutineScope
@@ -19,13 +17,13 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import software.ralf.app.platform.ExperimentalAppPlatform
 import software.ralf.app.platform.internal.IgnoreNative
 import software.ralf.app.platform.internal.IgnoreWasm
-import software.ralf.app.platform.internal.currentThreadName
+import software.ralf.app.platform.internal.MarkedDispatcher
+import software.ralf.app.platform.internal.createMarkedDispatcher
 import software.ralf.app.platform.presenter.BaseModel
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalAppPlatform::class)
@@ -34,19 +32,21 @@ class LaunchMoleculePresenterTest {
   @Test
   @IgnoreNative
   @IgnoreWasm
-  fun `the first present call happens inline and the second present call happens on the background thread`() =
+  fun `the first present call happens inline and the second uses the supplied dispatcher`() =
     runTest {
       val inputFlow = MutableStateFlow("1")
-      TestPresenter().test(this, inputFlow, UnconfinedTestDispatcher()) {
-        val model1 = awaitItem()
-        inputFlow.value = "2"
-        val model2 = awaitItem()
+      val markedDispatcher = createMarkedDispatcher()
+      try {
+        ThreadPresenter(markedDispatcher).test(this, inputFlow, markedDispatcher.dispatcher) {
+          val model1 = awaitItem()
+          inputFlow.value = "2"
+          val model2 = awaitItem()
 
-        val testRunnerPackage = "kotlinx.coroutines.test"
-        assertThat(model1.threadName).startsWith("Test worker")
-        assertThat(model1.threadName).contains(testRunnerPackage)
-        assertThat(model2.threadName).startsWith("Test worker")
-        assertThat(model2.threadName).doesNotContain(testRunnerPackage)
+          assertThat(model1.ranOnMarkedDispatcher).isFalse()
+          assertThat(model2.ranOnMarkedDispatcher).isTrue()
+        }
+      } finally {
+        markedDispatcher.close()
       }
     }
 
@@ -232,14 +232,19 @@ class LaunchMoleculePresenterTest {
     assertFailsWith<IllegalStateException> { moleculeScope.launchMoleculePresenter(presenter, 1) }
   }
 
-  private class TestPresenter : MoleculePresenter<StateFlow<String>, TestPresenter.Model> {
+  private class ThreadPresenter(private val markedDispatcher: MarkedDispatcher) :
+    MoleculePresenter<StateFlow<String>, ThreadPresenter.Model> {
+
     @Composable
     override fun present(input: StateFlow<String>): Model {
       val value by input.collectAsState()
 
-      return Model(threadName = currentThreadName + value)
+      return Model(
+        value = value,
+        ranOnMarkedDispatcher = markedDispatcher.isCurrentThreadMarked(),
+      )
     }
 
-    data class Model(val threadName: String) : BaseModel
+    data class Model(val value: String, val ranOnMarkedDispatcher: Boolean) : BaseModel
   }
 }


### PR DESCRIPTION
Use a controlled marked dispatcher instead of Gradle thread names so `LaunchMoleculePresenterTest` verifies inline startup and dispatched recomposition consistently across local and CI runners.