### PR TITLE
Preserve decorated test scope lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Preserve decorated coroutine scope lifetimes in `FakeMoleculeScopeFactory` instead of creating unmanaged test jobs.
+
 ### Security
 
 ### Other Notes & Contributions

--- a/presenter-molecule/testing/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/FakeMoleculeScopeFactory.kt
+++ b/presenter-molecule/testing/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/FakeMoleculeScopeFactory.kt
@@ -1,11 +1,9 @@
 package software.ralf.app.platform.presenter.molecule
 
 import app.cash.molecule.RecompositionMode
-import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 
 /**
@@ -24,22 +22,10 @@ public class FakeMoleculeScopeFactory(private val coroutineScope: CoroutineScope
     return if (coroutineScope is TestScope) {
       coroutineScope.moleculeScope(coroutineContext)
     } else {
-      @OptIn(ExperimentalStdlibApi::class)
-      val coroutineDispatcher = coroutineScope.coroutineContext[ContinuationInterceptor.Key]
-      if (coroutineDispatcher is TestDispatcher) {
-        // If this is a TestDispatcher, then this scope was likely based on a TestScope
-        // and we can create a wrapper. E.g. this happens if you do
-        // `testScope + CoroutineName(..)`, which returns a CoroutineScope and not
-        // TestScope.
-        TestScope(coroutineScope.coroutineContext).moleculeScope(coroutineContext)
-      } else {
-        // Respect the choice not to use a TestScope, which also initializes the whole test
-        // machinery with skipping.
-        MoleculeScope(
-          coroutineScope = coroutineScope + coroutineContext,
-          recompositionMode = RecompositionMode.Immediate,
-        )
-      }
+      MoleculeScope(
+        coroutineScope = coroutineScope + coroutineContext,
+        recompositionMode = RecompositionMode.Immediate,
+      )
     }
   }
 }

--- a/presenter-molecule/testing/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/FakeMoleculeScopeFactoryTest.kt
+++ b/presenter-molecule/testing/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/FakeMoleculeScopeFactoryTest.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.runTest
 import software.ralf.app.platform.internal.IgnoreWasm
 
@@ -48,6 +50,17 @@ class FakeMoleculeScopeFactoryTest {
 
     val name = scope.coroutineScope.coroutineContext[CoroutineName.Key]
     assertThat(name?.name).isEqualTo("test")
+  }
+
+  @Test
+  fun `a decorated TestScope does not create an unmanaged child`() = runTest {
+    val testJob = coroutineContext.job
+    val originalChildren = testJob.children.toList()
+
+    FakeMoleculeScopeFactory(this)
+      .createMoleculeScopeFromCoroutineScope(this + CoroutineName("decorated"))
+
+    assertThat(testJob.children.toList()).isEqualTo(originalChildren)
   }
 
   @Test


### PR DESCRIPTION
Avoid reconstructing a `TestScope` from an arbitrary scope that happens to use a test dispatcher. Preserving the supplied scope prevents an unmanaged child job—and current coroutine-test rejection—when callers decorate a test scope.