### PR TITLE
Retain inactive Molecule presenter state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 
 - Add `@ExperimentalAppPlatform` in `:common:public` for APIs that require explicit consumer opt-in.
 - Add experimental `MoleculePresenter.presentDetached()` to compose presenter subtrees in detached Molecule hierarchies so busy parent presenters do not recompose slower child presenters.
+- Add experimental `RetainedValuesStoreRegistry.returningRetainedValuesStoreProvider()` for retaining child `MoleculePresenter` state while it temporarily leaves the composition.
 - Add experimental Molecule presenter-backed text field state helpers for sharing text input state between presenters and Compose renderers.
 - Add experimental `ReturningSaveableStateHolder` in `:presenter-molecule:public` for preserving `rememberSaveable` state in value-returning Molecule presenter subtrees.
 - Add experimental Navigation 3 presenter backstack APIs and the `enableMoleculePresenterBackstack` Gradle plugin option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add experimental `RetainedValuesStoreRegistry.returningRetainedValuesStoreProvider()` for retaining child `MoleculePresenter` state while it temporarily leaves the composition.
+
 ### Changed
 
 - Upgrade KSP to `2.3.11`.
@@ -109,7 +111,6 @@
 
 - Add `@ExperimentalAppPlatform` in `:common:public` for APIs that require explicit consumer opt-in.
 - Add experimental `MoleculePresenter.presentDetached()` to compose presenter subtrees in detached Molecule hierarchies so busy parent presenters do not recompose slower child presenters.
-- Add experimental `RetainedValuesStoreRegistry.returningRetainedValuesStoreProvider()` for retaining child `MoleculePresenter` state while it temporarily leaves the composition.
 - Add experimental Molecule presenter-backed text field state helpers for sharing text input state between presenters and Compose renderers.
 - Add experimental `ReturningSaveableStateHolder` in `:presenter-molecule:public` for preserving `rememberSaveable` state in value-returning Molecule presenter subtrees.
 - Add experimental Navigation 3 presenter backstack APIs and the `enableMoleculePresenterBackstack` Gradle plugin option.

--- a/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/KmpPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/ralf/app/platform/gradle/buildsrc/KmpPlugin.kt
@@ -371,6 +371,7 @@ public open class KmpPlugin : Plugin<Project> {
       plugins.apply(Plugins.COMPOSE_COMPILER)
       kmpExtension.sourceSets.getByName("commonMain").dependencies {
         implementation(libs.findLibrary("molecule.runtime").get().get().toString())
+        implementation(libs.findLibrary("compose.runtime.retain").get().get().toString())
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/AppPlatformExtension.kt
+++ b/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/AppPlatformExtension.kt
@@ -371,6 +371,7 @@ private fun Project.enableMoleculePresenters() {
   plugins.withId(PluginIds.KOTLIN_MULTIPLATFORM) {
     kmpExtension.sourceSets.getByName("commonMain").dependencies {
       implementation("app.cash.molecule:molecule-runtime:$MOLECULE_VERSION")
+      implementation("androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION")
       implementation("$APP_PLATFORM_GROUP:presenter-molecule-public:$APP_PLATFORM_VERSION")
     }
     testingSourceSets.forEach { sourceSetName ->
@@ -382,6 +383,10 @@ private fun Project.enableMoleculePresenters() {
 
   withJvmOrAndroidPlugin {
     dependencies.add("implementation", "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION")
+    dependencies.add(
+      "implementation",
+      "androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION",
+    )
     dependencies.add(
       "implementation",
       "$APP_PLATFORM_GROUP:presenter-molecule-public:$APP_PLATFORM_VERSION",

--- a/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/AppPlatformPluginDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/AppPlatformPluginDependencyTest.kt
@@ -7,8 +7,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import gradle_plugin.BuildConfig.APP_PLATFORM_GROUP
 import gradle_plugin.BuildConfig.APP_PLATFORM_VERSION
-import gradle_plugin.BuildConfig.COMPOSE_MULTIPLATFORM_VERSION
-import gradle_plugin.BuildConfig.MOLECULE_VERSION
 import kotlin.test.Test
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -18,54 +16,6 @@ import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import software.ralf.app.platform.gradle.AppPlatformExtension.Companion.appPlatform
 
 class AppPlatformPluginDependencyTest {
-
-  @Test
-  fun `KMP Molecule presenter wiring includes Compose runtime retain`() {
-    val project = createProject(name = "impl")
-    project.plugins.apply(PluginIds.KOTLIN_MULTIPLATFORM)
-    project.plugins.apply(AppPlatformPlugin::class.java)
-
-    project.appPlatform.enableMoleculePresenters(true)
-
-    project.evaluate()
-
-    project.assertHasDependency(
-      "commonMainImplementation",
-      "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION",
-    )
-    project.assertHasDependency(
-      "commonMainImplementation",
-      "androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION",
-    )
-    project.assertHasDependency(
-      "commonMainImplementation",
-      appPlatformDependency("presenter-molecule-public"),
-    )
-  }
-
-  @Test
-  fun `JVM Molecule presenter wiring includes Compose runtime retain`() {
-    val project = createProject(name = "impl")
-    project.plugins.apply(PluginIds.KOTLIN_JVM)
-    project.plugins.apply(AppPlatformPlugin::class.java)
-
-    project.appPlatform.enableMoleculePresenters(true)
-
-    project.evaluate()
-
-    project.assertHasDependency(
-      "implementation",
-      "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION",
-    )
-    project.assertHasDependency(
-      "implementation",
-      "androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION",
-    )
-    project.assertHasDependency(
-      "implementation",
-      appPlatformDependency("presenter-molecule-public"),
-    )
-  }
 
   @Test
   fun `AGP built-in Kotlin Android application receives Metro public and impl dependencies`() {

--- a/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/AppPlatformPluginDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/AppPlatformPluginDependencyTest.kt
@@ -7,6 +7,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import gradle_plugin.BuildConfig.APP_PLATFORM_GROUP
 import gradle_plugin.BuildConfig.APP_PLATFORM_VERSION
+import gradle_plugin.BuildConfig.COMPOSE_MULTIPLATFORM_VERSION
+import gradle_plugin.BuildConfig.MOLECULE_VERSION
 import kotlin.test.Test
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -16,6 +18,54 @@ import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import software.ralf.app.platform.gradle.AppPlatformExtension.Companion.appPlatform
 
 class AppPlatformPluginDependencyTest {
+
+  @Test
+  fun `KMP Molecule presenter wiring includes Compose runtime retain`() {
+    val project = createProject(name = "impl")
+    project.plugins.apply(PluginIds.KOTLIN_MULTIPLATFORM)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMoleculePresenters(true)
+
+    project.evaluate()
+
+    project.assertHasDependency(
+      "commonMainImplementation",
+      "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION",
+    )
+    project.assertHasDependency(
+      "commonMainImplementation",
+      "androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION",
+    )
+    project.assertHasDependency(
+      "commonMainImplementation",
+      appPlatformDependency("presenter-molecule-public"),
+    )
+  }
+
+  @Test
+  fun `JVM Molecule presenter wiring includes Compose runtime retain`() {
+    val project = createProject(name = "impl")
+    project.plugins.apply(PluginIds.KOTLIN_JVM)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMoleculePresenters(true)
+
+    project.evaluate()
+
+    project.assertHasDependency(
+      "implementation",
+      "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION",
+    )
+    project.assertHasDependency(
+      "implementation",
+      "androidx.compose.runtime:runtime-retain:$COMPOSE_MULTIPLATFORM_VERSION",
+    )
+    project.assertHasDependency(
+      "implementation",
+      appPlatformDependency("presenter-molecule-public"),
+    )
+  }
 
   @Test
   fun `AGP built-in Kotlin Android application receives Metro public and impl dependencies`() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", vers
 build-config-gradle-plugin = { module = "com.github.gmazzo.buildconfig:plugin", version.ref = "build-config" }
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+compose-runtime-retain = { module = "androidx.compose.runtime:runtime-retain", version.ref = "compose-multiplatform" }
 compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "android-compose-version" }
 compose-ui-back-handler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "android-compose-version" }

--- a/presenter-molecule/public/api/desktop/public.api
+++ b/presenter-molecule/public/api/desktop/public.api
@@ -31,6 +31,10 @@ public final class software/ralf/app/platform/presenter/molecule/ReturningCompos
 	public static final fun returningCompositionLocalProvider ([Landroidx/compose/runtime/ProvidedValue;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lsoftware/ralf/app/platform/presenter/BaseModel;
 }
 
+public final class software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProviderKt {
+	public static final fun returningRetainedValuesStoreProvider (Landroidx/compose/runtime/retain/RetainedValuesStoreRegistry;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lsoftware/ralf/app/platform/presenter/BaseModel;
+}
+
 public final class software/ralf/app/platform/presenter/molecule/backgesture/BackEventPresenter {
 	public static final field $stable I
 	public static final field Companion Lsoftware/ralf/app/platform/presenter/molecule/backgesture/BackEventPresenter$Companion;

--- a/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
@@ -59,8 +59,7 @@ import software.ralf.app.platform.presenter.BaseModel
  * Retained values stay in memory, may hold values that are not saveable, and do not survive
  * recreation of the root presenter or process death. Put state that must survive those events in an
  * injected state owner or repository. For state shared across siblings or deeply nested presenters,
- * prefer an injected owner over threading it through every level. This API does not install a
- * saveable-state owner or make `rememberSaveable` survive root recreation.
+ * prefer an injected owner over threading it through every level.
  *
  * The `enableMoleculePresenters(true)` Gradle plugin option adds Compose Runtime Retain together
  * with Molecule, so consumers should not declare this runtime separately.

--- a/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
@@ -1,0 +1,77 @@
+package software.ralf.app.platform.presenter.molecule
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.retain.RetainedValuesStoreRegistry
+import software.ralf.app.platform.ExperimentalAppPlatform
+import software.ralf.app.platform.presenter.BaseModel
+
+/**
+ * Composes [content] in the retained-values store associated with [key] and returns its model.
+ *
+ * State created with `remember`, `collectAsState`, or `produceState` normally lives only while its
+ * call remains in the presenter composition. Use `retain` inside [content] for arbitrary in-memory
+ * state that should return after a child presenter temporarily leaves the hierarchy. The parent
+ * selecting the active child owns a `RetainedValuesStoreRegistry`, retained with
+ * `retainRetainedValuesStoreRegistry`, and composes each child with a stable logical key:
+ * ```
+ * @OptIn(ExperimentalAppPlatform::class)
+ * class AuthPresenter(
+ *   private val createLoginPresenter: () -> LoginPresenter,
+ *   private val createRegistrationPresenter: () -> RegistrationPresenter,
+ * ) : MoleculePresenter<Destination, BaseModel> {
+ *   @Composable
+ *   override fun present(input: Destination): BaseModel {
+ *     val retainedState = retainRetainedValuesStoreRegistry()
+ *     return when (input) {
+ *       Destination.Login ->
+ *         retainedState.returningRetainedValuesStoreProvider("login") {
+ *           val presenter = remember { createLoginPresenter() }
+ *           presenter.present(Unit)
+ *         }
+ *       Destination.Registration ->
+ *         retainedState.returningRetainedValuesStoreProvider("registration") {
+ *           val presenter = remember { createRegistrationPresenter() }
+ *           presenter.present(Unit)
+ *         }
+ *     }
+ *   }
+ * }
+ *
+ * class LoginPresenter : MoleculePresenter<Unit, LoginPresenter.Model> {
+ *   @Composable
+ *   override fun present(input: Unit): Model {
+ *     var email by retain { mutableStateOf("") }
+ *     return Model(email = email, onEmailChanged = { email = it })
+ *   }
+ *
+ *   data class Model(
+ *     val email: String,
+ *     val onEmailChanged: (String) -> Unit,
+ *   ) : BaseModel
+ * }
+ * ```
+ *
+ * Use a key with stable equality and hash-code behavior that identifies the logical child. Do not
+ * compose the same key in two active providers. Call [RetainedValuesStoreRegistry.clearChild] when
+ * an inactive child's state is permanently obsolete, or [RetainedValuesStoreRegistry.clearChildren]
+ * when pruning several keys.
+ *
+ * Retained values stay in memory, may hold values that are not saveable, and do not survive
+ * recreation of the root presenter or process death. Put state that must survive those events in an
+ * injected state owner or repository. For state shared across siblings or deeply nested presenters,
+ * prefer an injected owner over threading it through every level. This API does not install a
+ * saveable-state owner or make `rememberSaveable` survive root recreation.
+ *
+ * The `enableMoleculePresenters(true)` Gradle plugin option adds Compose Runtime Retain together
+ * with Molecule, so consumers should not declare this runtime separately.
+ */
+@ExperimentalAppPlatform
+@Composable
+public fun <ModelT : BaseModel> RetainedValuesStoreRegistry.returningRetainedValuesStoreProvider(
+  key: Any?,
+  content: @Composable () -> ModelT,
+): ModelT {
+  var model: ModelT? = null
+  LocalRetainedValuesStoreProvider(key) { model = content() }
+  return checkNotNull(model)
+}

--- a/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProvider.kt
@@ -60,9 +60,6 @@ import software.ralf.app.platform.presenter.BaseModel
  * recreation of the root presenter or process death. Put state that must survive those events in an
  * injected state owner or repository. For state shared across siblings or deeply nested presenters,
  * prefer an injected owner over threading it through every level.
- *
- * The `enableMoleculePresenters(true)` Gradle plugin option adds Compose Runtime Retain together
- * with Molecule, so consumers should not declare this runtime separately.
  */
 @ExperimentalAppPlatform
 @Composable

--- a/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProviderTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/ReturningRetainedValuesStoreProviderTest.kt
@@ -1,0 +1,65 @@
+package software.ralf.app.platform.presenter.molecule
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.retain.retain
+import androidx.compose.runtime.retain.retainRetainedValuesStoreRegistry
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import software.ralf.app.platform.ExperimentalAppPlatform
+import software.ralf.app.platform.presenter.BaseModel
+
+@OptIn(ExperimentalAppPlatform::class)
+class ReturningRetainedValuesStoreProviderTest {
+  @Test
+  fun `retained child state returns after the child leaves composition`() = runTest {
+    val showChild = MutableStateFlow(true)
+    val presenter = ParentPresenter(ChildPresenter())
+
+    presenter.test(this, showChild) {
+      val firstModel = awaitItem() as Model.Child
+      assertThat(firstModel.count).isEqualTo(0)
+
+      firstModel.onIncrement()
+      showChild.value = false
+      assertThat(awaitItem()).isEqualTo(Model.Hidden)
+
+      showChild.value = true
+      val restoredModel = awaitItem() as Model.Child
+      assertThat(restoredModel.count).isEqualTo(1)
+    }
+  }
+
+  private class ParentPresenter(private val childPresenter: ChildPresenter) :
+    MoleculePresenter<Boolean, Model> {
+    @Composable
+    override fun present(input: Boolean): Model {
+      val retainedValuesStoreRegistry = retainRetainedValuesStoreRegistry()
+      return if (input) {
+        retainedValuesStoreRegistry.returningRetainedValuesStoreProvider("child") {
+          childPresenter.present(Unit)
+        }
+      } else {
+        Model.Hidden
+      }
+    }
+  }
+
+  private class ChildPresenter : MoleculePresenter<Unit, Model.Child> {
+    @Composable
+    override fun present(input: Unit): Model.Child {
+      val counter = retain { Counter() }
+      return Model.Child(count = counter.count, onIncrement = { counter.count++ })
+    }
+  }
+
+  private class Counter(var count: Int = 0)
+
+  private sealed interface Model : BaseModel {
+    data object Hidden : Model
+
+    data class Child(val count: Int, val onIncrement: () -> Unit) : Model
+  }
+}


### PR DESCRIPTION
Allow child `MoleculePresenter`s to leave and reenter composition without losing in-memory state. This backports openai-android commit `f5f85a4039ae0ae6cca21035dfe12001c76308ef` with an experimental value-returning retained-values provider, caller-facing KDoc, and Compose Runtime Retain wiring through `enableMoleculePresenters` for KMP and JVM/Android consumers.