### PR TITLE
Clarify presenter model stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Clarify that `BaseModel` implementations can use observable mutable state that satisfies the Compose stability contract.
 - Upgrade KSP to `2.3.11`.
 - Upgrade Compose Multiplatform to `1.12.0`.
 

--- a/presenter/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/BaseModel.kt
+++ b/presenter/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/BaseModel.kt
@@ -10,9 +10,9 @@ package software.ralf.app.platform.presenter
  * }
  * ```
  *
- * Models must be immutable. Making models mutable and changing their state is an error and leads to
- * undesired results or crashes. While technically not required, common practice is to use a `data
- * class` for models.
+ * Models must be immutable or satisfy the Compose stability contract by notifying composition when
+ * public state changes. Mutating a previously returned model without observable state can produce
+ * incorrect results or crashes. Immutable data classes are the common default.
  *
  * Using sealed hierarchies for models is common and allows to differentiate between states better:
  * ```


### PR DESCRIPTION
Document the observable-state contract so model implementations can use Compose stability safely without implying that every model must be structurally immutable.