### PR TITLE
Make MoleculePresenter a functional interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Allow constructing `MoleculePresenter` instances with SAM syntax.
 - Clarify that `BaseModel` implementations can use observable mutable state that satisfies the Compose stability contract.
 - Upgrade KSP to `2.3.11`.
 - Upgrade Compose Multiplatform to `1.12.0`.

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -41,7 +41,7 @@ The [MoleculePresenter](https://github.com/vRallev/app-platform/blob/main/presen
 interface looks like this:
 
 ```kotlin
-interface MoleculePresenter<InputT : Any, ModelT : BaseModel> {
+fun interface MoleculePresenter<InputT : Any, ModelT : BaseModel> {
   @Composable
   fun present(input: InputT): ModelT
 }

--- a/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/MoleculePresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/molecule/MoleculePresenter.kt
@@ -101,7 +101,7 @@ import software.ralf.app.platform.presenter.Presenter
  * }
  * ```
  */
-public interface MoleculePresenter<InputT : Any, ModelT : BaseModel> {
+public fun interface MoleculePresenter<InputT : Any, ModelT : BaseModel> {
   /** Called every time state of the composable changes to produce a new model. */
   @Composable public fun present(input: InputT): ModelT
 }

--- a/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
@@ -54,13 +54,7 @@ class LaunchMoleculePresenterTest {
   fun `the presenter is called and computes a new model whenever the input changes`() = runTest {
     data class Model(val value: String) : BaseModel
 
-    val presenter =
-      object : MoleculePresenter<Int, Model> {
-        @Composable
-        override fun present(input: Int): Model {
-          return Model(input.toString())
-        }
-      }
+    val presenter = MoleculePresenter<Int, Model> { input -> Model(input.toString()) }
 
     val inputFlow = MutableStateFlow(1)
 


### PR DESCRIPTION
Allow tests and small integrations to create `MoleculePresenter` instances with SAM syntax while preserving the existing composable presenter contract.