### PR TITLE
Mark presenter models stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Mark `BaseModel` as stable so Compose treats `MoleculePresenter` models consistently through the shared interface.
 - Allow constructing `MoleculePresenter` instances with SAM syntax.
 - Clarify that `BaseModel` implementations can use observable mutable state that satisfies the Compose stability contract.
 - Upgrade KSP to `2.3.11`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", vers
 build-config-gradle-plugin = { module = "com.github.gmazzo.buildconfig:plugin", version.ref = "build-config" }
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+compose-runtime-annotation = { module = "androidx.compose.runtime:runtime-annotation", version.ref = "compose-multiplatform" }
 compose-runtime-retain = { module = "androidx.compose.runtime:runtime-retain", version.ref = "compose-multiplatform" }
 compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "android-compose-version" }
 compose-ui-back-handler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }

--- a/presenter/public/build.gradle
+++ b/presenter/public/build.gradle
@@ -5,3 +5,7 @@ plugins {
 appPlatformBuildSrc {
     enablePublishing true
 }
+
+dependencies {
+    commonMainApi libs.compose.runtime.annotation
+}

--- a/presenter/public/build.gradle
+++ b/presenter/public/build.gradle
@@ -7,5 +7,5 @@ appPlatformBuildSrc {
 }
 
 dependencies {
-    commonMainApi libs.compose.runtime.annotation
+    commonMainImplementation libs.compose.runtime.annotation
 }

--- a/presenter/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/BaseModel.kt
+++ b/presenter/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/BaseModel.kt
@@ -1,5 +1,7 @@
 package software.ralf.app.platform.presenter
 
+import androidx.compose.runtime.Stable
+
 /**
  * `Presenters` produce a stream of models that represents the state of this presenter. Concrete
  * model types are usually implemented as inner classes of the presenter, e.g.
@@ -52,4 +54,4 @@ package software.ralf.app.platform.presenter
  *
  * [BaseModel] is a marker interface for all models that can be used for extensions.
  */
-public interface BaseModel
+@Stable public interface BaseModel


### PR DESCRIPTION
Declare the shared `BaseModel` contract as stable so Compose can treat `MoleculePresenter` models consistently at call sites that only know the marker interface. Keep the lightweight runtime annotation dependency internal so generic presenter consumers do not inherit it on their compile classpaths.