### PR TITLE
Expose project-path module type parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add experimental `withLocalRetainedValuesStore()` for retaining child `MoleculePresenter` state with caller-owned managed stores while it temporarily leaves the composition.
+- Expose `String.moduleTypeFromProjectPath()` for parsing module types without a `Project` instance.
 
 ### Changed
 

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -89,5 +89,6 @@ public final class software/ralf/app/platform/gradle/ModuleTypeKt {
 	public static final fun isRobotsModule (Lorg/gradle/api/Project;)Z
 	public static final fun isTestingModule (Lorg/gradle/api/Project;)Z
 	public static final fun isUsingModuleStructure (Lorg/gradle/api/Project;)Z
+	public static final fun moduleTypeFromProjectPath (Ljava/lang/String;)Lsoftware/ralf/app/platform/gradle/ModuleType;
 }
 

--- a/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleType.kt
+++ b/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleType.kt
@@ -88,7 +88,8 @@ public enum class ModuleType(
 public val Project.moduleType: ModuleType
   get() = path.moduleTypeFromProjectPath()
 
-internal fun String.moduleTypeFromProjectPath(): ModuleType {
+/** Returns the module type inferred from this Gradle project path. */
+public fun String.moduleTypeFromProjectPath(): ModuleType {
   val name = substringAfterLast(':')
 
   val isRobots = name.endsWith("-robots")

--- a/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleType.kt
+++ b/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleType.kt
@@ -88,7 +88,13 @@ public enum class ModuleType(
 public val Project.moduleType: ModuleType
   get() = path.moduleTypeFromProjectPath()
 
-/** Returns the module type inferred from this Gradle project path. */
+/**
+ * Returns the module type inferred from an absolute Gradle project path such as `:feature:public`.
+ *
+ * Explicit module types in the final path segment take precedence over app-like parent segments.
+ * Returns [ModuleType.UNKNOWN] when no supported module naming convention matches. The receiver is
+ * not otherwise validated as a Gradle project path.
+ */
 public fun String.moduleTypeFromProjectPath(): ModuleType {
   val name = substringAfterLast(':')
 


### PR DESCRIPTION
Allow Gradle plugin consumers to reuse `String.moduleTypeFromProjectPath()` when they need module classification without an available `Project` instance.