### PR TITLE
Add project-neutral App Platform skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add project-neutral coding agent skills for App Platform module structure, scopes, presenters, renderers, templates, and testing.
 - Add experimental `withLocalRetainedValuesStore()` for retaining child `MoleculePresenter` state with caller-owned managed stores while it temporarily leaves the composition.
 - Expose `String.moduleTypeFromProjectPath()` for parsing module types without a `Project` instance.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -81,6 +81,18 @@ are explained in more detail in many of the following sections.
     the opinionated module structure. Compose UI can be enabled without using `Metro` or
     `kotlin-inject-anvil`. When you do want DI, Metro is the recommended default.
 
+## Coding agent skills
+
+This repository includes project-neutral skills for coding agents working on applications built with App Platform. Choose the skill that matches the change:
+
+| Skill | Use for |
+| --- | --- |
+| [Module structure](https://github.com/vRallev/app-platform/blob/main/skills/app-platform-module-structure/SKILL.md) | Public, implementation, testing, and robot module boundaries; app assembly; and Gradle checks |
+| [Scopes](https://github.com/vRallev/app-platform/blob/main/skills/app-platform-scope/SKILL.md) | App Platform lifetimes, coroutine scopes, and Metro graph integration |
+| [Presenters](https://github.com/vRallev/app-platform/blob/main/skills/app-platform-presenters/SKILL.md) | `MoleculePresenter` models, state, composition, hosting, and template selection |
+| [Renderers](https://github.com/vRallev/app-platform/blob/main/skills/app-platform-renderers/SKILL.md) | Compose and Android View renderers, factories, child rendering, and template layouts |
+| [Testing](https://github.com/vRallev/app-platform/blob/main/skills/app-platform-testing/SKILL.md) | Fakes, shared unit tests, optional Desktop renderer tests, and robot integration tests |
+
 ## Snapshot
 
 To import snapshot builds use following repository:

--- a/skills/app-platform-module-structure/SKILL.md
+++ b/skills/app-platform-module-structure/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: app-platform-module-structure
+description: Design and verify App Platform module boundaries. Use when placing shared APIs, implementations, internal code, fakes, robots, or app assembly; adding Gradle modules or dependencies; enabling module structure checks; or fixing forbidden dependency errors.
+---
+
+# App Platform Module Structure
+
+App Platform applies dependency inversion at the Gradle module boundary. Consumers compile against small public contracts, concrete implementations stay hidden, and the application chooses implementations at its assembly boundary. This feature is optional and separate from scopes, presenters, renderers, and DI.
+
+Follow the consuming project's App Platform version, target setup, and Gradle conventions. Before editing, read `settings.gradle` or `settings.gradle.kts`, repository instructions, and nearby module build files. Examples omit imports.
+
+## Choose a boundary
+
+First identify the owning library, its consumers, the stable contract they need, and the concrete details they should not see. Also check whether the library has platform code, alternate implementations, reusable fakes, or reusable UI robots.
+
+Choose the smallest boundary that preserves dependency inversion. Do not create a module only because several files share a category. A library can have only `:public` when its reusable code needs no hidden implementation, such as utilities or shared UI components.
+
+## Module types
+
+Keep sibling modules under one library path, such as `:account:public` and `:account:impl`.
+
+| Module | Put here | Used by |
+| --- | --- | --- |
+| `:public` | Shared contracts, models, and code intentionally safe to expose | Other libraries, implementations, tests, and apps |
+| `:impl` or `:impl-name` | Concrete implementations, presenter and renderer implementations, DI bindings, and platform details | Final app assembly; zero or more per library |
+| `:internal` | Private implementation-side code shared by sibling non-public modules | Non-public modules in the same library; rarely app assembly |
+| `:testing` | Reusable fakes and test helpers for the public API | Tests and other test-only modules |
+| `:*-robots` | Reusable UI or integration-test robots; usually `:impl-robots` | UI or integration tests and other robot modules |
+| `:app` or another recognized app path | Final composition, selected implementations, and platform host code | The final binary |
+
+Keep implementation-private models in `:impl`. Keep platform launcher, manifest, packaging, window, activity, and native host code in the platform app shell or the target source set that needs it.
+
+## Dependency rules
+
+- Among structured modules, `:public` depends only on other `:public` modules. Keep implementation and platform types out of public signatures.
+- Feature implementations depend on other libraries' public contracts. Final app assembly selects and imports their `:impl` modules.
+- `:impl` to `:impl` dependencies are forbidden by default. A library can share private code through `:internal`, or allow same-library implementation dependencies so one implementation builds on another.
+- `:internal` stays on the implementation side of its library. A sibling `:public` module cannot import it. App assembly may import it, but ordinary cross-library consumers may not.
+- Ordinary production modules add `:testing` only to test configurations and robots only to UI or integration-test configurations. Test-only `:testing` and robot modules may use `:testing` from their main source sets. Robot modules may also depend on other robot modules. None belongs on the final runtime classpath.
+- App modules may import `:impl` and `:internal` modules. Their production classpaths must still exclude `:testing` and robot modules.
+
+Gradle's `api` versus `implementation` choice is separate. Use `api` only when a dependency's types are part of the exposed API.
+
+If many modules need a concrete type, stop and define or revise its public contract. Do not move test helpers into production code to work around visibility.
+
+## Enable the structure
+
+Enable the option in each participating module, directly or through the consuming project's convention plugin:
+
+```kotlin
+plugins {
+  id("software.ralf.app.platform")
+}
+
+appPlatform {
+  enableModuleStructure(true)
+}
+```
+
+Enabling it in one module does not configure its consumers. For each enabled module, the plugin:
+
+- Checks that the module name is a supported type.
+- Adds its sibling `:public` dependency to `:impl`, `:internal`, `:testing`, and robot modules when that module exists.
+- Adds the matching implementation to an `:impl-robots` module as an implementation dependency.
+- Supplies default archive names and Android namespaces while preserving explicit values.
+- Registers `checkModuleStructureDependencies` and connects it to Gradle's `check` lifecycle when available.
+
+Automatic Android and Android-KMP namespaces require a `GROUP` Gradle property when no explicit namespace is set. Public modules omit `.public` from the generated namespace, and hyphens become dots.
+
+Do not repeat automatic sibling dependencies unless the consuming build has a documented reason.
+
+## Assemble the application
+
+The app boundary imports concrete feature modules and builds the root graph, scope, template, and platform entry points. When it relies on App Platform's default implementations, enable them there:
+
+```kotlin
+appPlatform {
+  addImplModuleDependencies(true)
+}
+```
+
+This adds App Platform implementation artifacts for enabled framework features. It does not discover or import the application's feature `:impl` modules.
+
+A shared KMP application assembly may use a path such as `:app-framework:impl`. Its leaf name still makes it an implementation module, even though it intentionally imports feature implementations. Keep the module-structure defaults but disable dependency enforcement only at that composition root:
+
+```kotlin
+appPlatform {
+  enableModuleStructure {
+    enableDependencyCheck(false)
+  }
+  addImplModuleDependencies(true)
+}
+```
+
+Fix ordinary feature dependency violations instead of disabling their checks.
+
+Some libraries use `:internal` for code shared by implementations. Others let one `:impl` module build on another and avoid a separate internal module. Enable that choice on the consuming implementation:
+
+```kotlin
+appPlatform {
+  enableModuleStructure {
+    allowLibraryImplToImplDependencies(true)
+  }
+}
+```
+
+This allows project implementation dependencies only within the same library. Cross-library and external implementation dependencies remain forbidden.
+
+## Add or split a library
+
+1. Map current consumers and choose the smallest stable contract.
+2. Add the required modules to Gradle settings, using one library parent:
+
+   ```kotlin
+   include(":account:public")
+   include(":account:impl")
+   include(":account:testing")
+   include(":account:impl-robots")
+   ```
+
+3. Put contracts and shared models in `:public`. Keep public APIs free of implementation and platform types.
+4. Put concrete code in one or more `:impl` modules. Use target source sets inside an implementation for platform-specific code; use named implementation modules when apps or vendors select different implementations.
+5. Choose how sibling implementations share code: add `:internal`, or enable same-library implementation dependencies and reuse an implementation module.
+6. Put reusable fakes in `:testing` and reusable UI robots in a robot module. Keep one-off test helpers beside their tests.
+7. Select implementations and assemble DI at the app boundary.
+8. Copy target and App Platform feature configuration from the closest matching modules instead of enabling every feature everywhere.
+
+A typical graph is:
+
+```text
+:checkout:impl  -> :account:public
+:app            -> :checkout:impl, :account:impl
+:checkout tests -> :account:testing
+```
+
+## Test and verify
+
+Run the consuming project's focused compile and test tasks for each changed module, then run:
+
+```shell
+./gradlew checkModuleStructureDependencies
+```
+
+The aggregate task checks supported production compile classpaths across Android, JVM, and KMP targets. It also checks Android and JVM test fixtures. Public test fixtures may use `:public` and `:testing`, but not `:impl`.
+
+When changing `:public`, run the project's API checks. When moving DI contributions or implementation selection, compile the real app graph and platform entry point. Recheck Gradle settings after adding or renaming modules.
+
+The dependency task checks declared dependencies whose names follow the module structure. It does not prove that public APIs are well designed, that transitive dependencies are harmless, or that source-set boundaries are correct. Review exported signatures and the effective dependency graph as well.
+
+Public docs: [module structure](https://vrallev.github.io/app-platform/module-structure/), [setup](https://vrallev.github.io/app-platform/setup/), and [testing](https://vrallev.github.io/app-platform/testing/).

--- a/skills/app-platform-module-structure/agents/openai.yaml
+++ b/skills/app-platform-module-structure/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Platform Module Structure"
+  short_description: "Design App Platform module boundaries"
+  default_prompt: "Use $app-platform-module-structure to place code and dependencies in App Platform modules and verify the module graph."

--- a/skills/app-platform-presenters/SKILL.md
+++ b/skills/app-platform-presenters/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: app-platform-presenters
+description: Build and test App Platform MoleculePresenters. Use when changing models, state, parent and child presenters, template selection or delegation, tests, or Gradle and host setup.
+---
+
+# App Platform Molecule Presenters
+
+`MoleculePresenter` uses the Compose runtime to turn inputs and injected data into a `BaseModel`. The UI or a parent presenter reads the model and sends events through its callbacks. Compose UI is optional.
+
+Before editing, identify the inputs, model, events, how long state must last, and who starts and stops the root. Follow the project's module, DI, and build choices. Check its App Platform version before using `ExperimentalAppPlatform` APIs. Examples omit imports; resolve unfamiliar APIs from existing code or matching public docs.
+
+## Models
+
+- Implement `MoleculePresenter<InputT, ModelT>` with `ModelT : BaseModel`. Include all state and callbacks the consumer needs.
+- Expose immutable model snapshots, preferably data classes or sealed types. Use `val` properties and immutable values, and return a new model when state changes. Keep equality and public types stable to satisfy `BaseModel`.
+- Prefer presenter interfaces with implementations supplied through DI. Put shared contracts and models in `:public`, implementations in `:impl`, and assemble them in the app. Keep implementations used by generated graphs across modules public.
+- Nest `Model` under its presenter. Put `present()` first, then helpers, the companion object, and nested types, with `Model` last.
+- When consumers need only some fields, define a partial `Model : BaseModel` interface in `:public`. An immutable model in `:impl` implements it and adds fields used only by the implementation. Use a concrete public model when consumers need all fields.
+
+  ```kotlin
+  // :public
+  interface SearchPresenter : MoleculePresenter<String, SearchPresenter.Model> {
+    interface Model : BaseModel {
+      val query: String
+    }
+  }
+
+  // :impl
+  class SearchPresenterImpl : SearchPresenter {
+    @Composable
+    override fun present(input: String): Model {
+      return Model(query = input, canSearch = input.isNotBlank())
+    }
+
+    data class Model(
+      override val query: String,
+      val canSearch: Boolean,
+    ) : SearchPresenter.Model
+  }
+  ```
+
+  Parents using `SearchPresenter` can read `query`; its renderer in `:impl` can also read `canSearch`.
+
+- When consumers only pass a model along, hide its type with a generic interface:
+
+  ```kotlin
+  interface CatalogPresenter<ModelT : BaseModel> : MoleculePresenter<Unit, ModelT>
+  ```
+
+  Consumers can use `CatalogPresenter<*>`. Parents that return different child models can use `BaseModel`.
+
+## Inputs
+
+Use constructor or assisted-factory arguments for fixed values, such as an item ID. Use `InputT` for changing values, such as a filter, and always read the latest input. Use `Unit` when there is no input.
+
+Keep callbacks on the model, not in inputs. Children report results through their models; parents decide what those results mean.
+
+## State and effects
+
+Keep mutable state, caches, scopes, and effects inside `present()`. Presenter fields hold dependencies and fixed arguments. Presenters must not be singletons.
+
+Use `remember` for local state and Compose runtime APIs such as `collectAsState` or `produceState` for changing data:
+
+```kotlin
+interface CounterPresenter : MoleculePresenter<Unit, CounterPresenter.Model> {
+  data class Model(
+    val count: Int,
+    val onIncrement: () -> Unit,
+  ) : BaseModel
+}
+
+class CounterPresenterImpl : CounterPresenter {
+  @Composable
+  override fun present(input: Unit): CounterPresenter.Model {
+    var count by remember { mutableIntStateOf(0) }
+    return CounterPresenter.Model(count = count, onIncrement = { count++ })
+  }
+}
+```
+
+Use `LaunchedEffect` to start work, `DisposableEffect` to clean up listeners, and `rememberCoroutineScope` for work from callbacks. Choose keys that restart work when needed. Don't start side effects directly in `present()`, which can run many times.
+
+## Parent and child presenters
+
+Call children with `present(input)`. Parents can select or combine their models to drive navigation. Create optional children through a factory inside the active branch and remember the instance. Call `present()` each time; do not remember its model. Children used on every call can be injected directly.
+
+To reset state for a new item, key both child creation and its `present()` call. Creating a new instance alone does not reset the composition:
+
+```kotlin
+return key(input.itemId) {
+  val child = remember { itemPresenterFactory.create(input.itemId) }
+  child.present(Unit)
+}
+```
+
+Use `androidx.compose.runtime.key`. For lists, key children by stable item IDs. To keep a child's lifetime, pass changing input and key only the state or effects that need to reset.
+
+Use `presentDetached()` only for costly child presenters. It can briefly pair new parent input with an old child model and does not inherit custom composition locals. Call `present()` directly when updates must agree or locals must be shared.
+
+### Backstack navigation
+
+For push and pop navigation, use experimental `presenterBackstack(initialPresenter) { models -> ... }`. Wrap its models in an app-specific `PresenterBackstackModel` with `onBack = { pop() }`. The helper provides `LocalBackstackScope`; children read `LocalBackstackScope.requireNotNull()` and call `push()`, `pop()`, or `replaceTop()` from model callbacks. The stack holds presenter instances, keeps every entry in composition, and ignores a pop at the root.
+
+Use `PresenterBackstackRenderer` for Navigation 3 UI. Set `appPlatform { enableMoleculePresenterBackstack(true) }` to add the module and enable Molecule presenters and Compose UI. See the [backstack guide](https://vrallev.github.io/app-platform/presenter/#presenter-backstack) for rendering and tests with a fake scope.
+
+## Template selection
+
+Use a `Template` for app-level layout and shell choices. Use a normal parent model for local component layout. A template is the app-specific root model, and its variants name semantic slots instead of holding an untyped list:
+
+```kotlin
+sealed interface AppTemplate : Template {
+  data class FullScreen(val content: BaseModel) : AppTemplate
+
+  data class ListDetail(
+    val list: BaseModel,
+    val detail: BaseModel,
+  ) : AppTemplate
+}
+```
+
+Wrap the root presenter in a template presenter. `toTemplate` follows `ModelDelegate` chains. It uses an `AppTemplate` returned by a child, or applies the default to the last delegated model:
+
+```kotlin
+class AppTemplatePresenter(
+  private val rootPresenter: MoleculePresenter<Unit, *>,
+) : MoleculePresenter<Unit, AppTemplate> {
+  @Composable
+  override fun present(input: Unit): AppTemplate {
+    return rootPresenter.present(Unit).toTemplate<AppTemplate> {
+      AppTemplate.FullScreen(it)
+    }
+  }
+}
+```
+
+Keep app-wide composition locals or presenter services around `rootPresenter.present(Unit)` at this boundary.
+
+An app-owned presenter can choose another layout without needing its own renderer:
+
+```kotlin
+data class Model(
+  val list: BaseModel,
+  val detail: BaseModel,
+) : BaseModel, ModelDelegate {
+  override fun delegate(): BaseModel = AppTemplate.ListDetail(list, detail)
+}
+```
+
+Delegation may pass through navigation models, but it must end. Keep reusable feature libraries independent of app template types; let an app-owned presenter choose their slots. Put a shared template contract in `:public` when app-owned presenters need it, and put the root wrapper in `:impl` or app assembly. Follow the root lifecycle guidance below when hosting the wrapper.
+
+Use the `app-platform-renderers` skill for template layout, child rendering, registration, factories, and platform hosts.
+
+## Platform code and UI
+
+Keep Android, Compose UI, `ViewModel`, navigation controllers, and resource IDs out of shared presenter APIs. Put platform work behind injected interfaces.
+
+Add a renderer only when a model needs direct visual output. Renderers handle localized text, layout, animations, and model callbacks. Presenters handle app state, navigation, and template selection. Register visible models through the app's renderer setup and check that the real app graph can resolve them.
+
+Follow the app's existing effect design. If the root creates a dispatcher, remember it there and share it with children. Handle platform effects in the host. Helpers such as `withCompositionLocal` can provide a value while returning a model.
+
+### Add a screen
+
+1. Define the presenter interface, inputs, immutable model, and callbacks.
+2. Implement `present()` and wire its dependencies through DI.
+3. Add and register a renderer if the model has visible output.
+4. Connect it to a parent presenter or wrap it in the app's template.
+5. Test presenter behavior with fakes; add UI tests for layout and event wiring when needed.
+
+## Start and stop presenters
+
+In a Compose host, remember the root and call `present()` directly if the host's composition should own its state. Otherwise, let a host own the scope and its cleanup:
+
+```kotlin
+class PresenterHost<ModelT : BaseModel>(
+  moleculeScopeFactory: MoleculeScopeFactory,
+  rootPresenter: MoleculePresenter<Unit, ModelT>,
+) {
+  private val moleculeScope = moleculeScopeFactory.createMoleculeScope()
+  val models = moleculeScope.launchMoleculePresenter(rootPresenter, Unit).model
+
+  fun close() {
+    moleculeScope.cancel()
+  }
+}
+```
+
+The factory applies platform defaults. Launching returns `Presenter<ModelT>`, with a `StateFlow` at `.model`. Pass a `StateFlow` input when the host needs to change it.
+
+Call the host's `close()` from its owner's cleanup, such as `ViewModel.onCleared()` or window cleanup. Stopping collection does not stop the presenters. Canceling a `MoleculeScope` also cancels the wrapped coroutine scope, so use a scope the host owns.
+
+## Keep state after a child leaves
+
+When a child stops being called, its ordinary remembered state and effects end. Keeping the presenter instance does not preserve its composition.
+
+- Use `withLocalRetainedValuesStore()` and `retain` to keep values in memory. Keep one managed store per child outside the active branch. Stores outlive inactive children and end with their owner. They do not keep effects running or survive root or process recreation.
+
+  This parent has two destinations and injected child factories:
+
+  ```kotlin
+  @OptIn(ExperimentalAppPlatform::class)
+  @Composable
+  override fun present(input: Destination): BaseModel {
+    val firstStore = key(Destination.First) { retainManagedRetainedValuesStore() }
+    val secondStore = key(Destination.Second) { retainManagedRetainedValuesStore() }
+
+    return when (input) {
+      Destination.First -> withLocalRetainedValuesStore(firstStore) {
+        val child = remember { createFirstPresenter() }
+        child.present(Unit)
+      }
+      Destination.Second -> withLocalRetainedValuesStore(secondStore) {
+        val child = remember { createSecondPresenter() }
+        child.present(Unit)
+      }
+    }
+  }
+  ```
+
+  Inside each child's `present()`, using the counter model above:
+
+  ```kotlin
+  var count by retain { mutableIntStateOf(0) }
+  return CounterPresenter.Model(count = count, onIncrement = { count++ })
+  ```
+
+- Use `ReturningSaveableStateHolder` and `rememberSaveable` for saveable values. Keep the holder in the parent. Use a different stable, saveable key for each child and remove saved state when a child is gone for good. Restoring after root or process recreation also needs a host that saves and restores the parent state registry.
+
+  ```kotlin
+  @OptIn(ExperimentalAppPlatform::class)
+  @Composable
+  override fun present(input: Destination): BaseModel {
+    val holder = rememberReturningSaveableStateHolder()
+
+    return when (input) {
+      Destination.First -> holder.SaveableStateProvider(key = "first") {
+        val child = remember { createFirstPresenter() }
+        child.present(Unit)
+      }
+      Destination.Second -> holder.SaveableStateProvider(key = "second") {
+        val child = remember { createSecondPresenter() }
+        child.present(Unit)
+      }
+    }
+  }
+  ```
+
+  Inside each child's `present()`:
+
+  ```kotlin
+  var count by rememberSaveable { mutableIntStateOf(0) }
+  return CounterPresenter.Model(count = count, onIncrement = { count++ })
+  ```
+
+For shared state or state that outlives the parent, inject an owner that lives long enough. Use persistent storage for data that must survive closing and reopening the app; a `StateFlow` alone does not save data.
+
+## Build setup
+
+Configure each module that defines, calls, or starts presenters, using the project's existing plugin version and conventions. A dependency's setup does not configure its consumers:
+
+```kotlin
+plugins {
+  id("software.ralf.app.platform")
+}
+
+appPlatform {
+  enableMoleculePresenters(true)
+}
+```
+
+This adds the Compose compiler, runtime, Molecule, presenter API, and test helpers. Don't repeat those dependencies. Enable Compose UI separately when needed.
+
+Bind presenter interfaces to implementations through the app's existing DI setup. For Metro, use `enableMetro(true)`.
+
+In modules that build the app, `addImplModuleDependencies(true)` supplies defaults such as `MoleculeScopeFactory`. Keep `:impl` dependencies out of feature API modules and check that the app's DI graph builds.
+
+The presenter option does not set Android's `isReturnDefaultValues`. Configure it in shared test setup if needed for Android stubs. Use Robolectric only for tests of real Android behavior.
+
+## Tests
+
+Prefer `commonTest`, fakes, and fast, deterministic dependencies. Call `runTest` directly and pass its scope to `presenter.test`:
+
+```kotlin
+class CounterPresenterTest {
+  @Test
+  fun incrementUpdatesTheModel() = runTest {
+    CounterPresenterImpl().test(this) {
+      val initial = awaitItem()
+      assertEquals(0, initial.count)
+      initial.onIncrement()
+      assertEquals(1, awaitItem().count)
+    }
+  }
+}
+```
+
+The helper uses the test's background scope. For inputs, pass `presenter.test(this, input = value)` or an input `StateFlow`.
+
+- Use Turbine's `awaitItem` and `expectNoEvents`. Drive model callbacks, input flows, and fakes; test behavior instead of private methods.
+- Test parents with fake children. Check child inputs, chosen models, state changes, and effects.
+- Test the default template wrapper, each `ModelDelegate` override, and state changes that select another template variant. These can be headless presenter tests.
+- Check state across recomposition, cleanup when children leave, and restored state when they return. Test the real host's save/restore path before claiming support for recreation.
+- Use virtual time instead of sleeps. Model emissions can skip intermediate states.
+
+Run focused tests. Compile affected targets and check host and DI setup when dependencies or host code change. Add UI tests only for behavior presenter tests cannot cover. Follow the project's formatting and API checks, and update docs when behavior changes.
+
+Public docs: [presenters](https://vrallev.github.io/app-platform/presenter/), [setup](https://vrallev.github.io/app-platform/setup/), [modules](https://vrallev.github.io/app-platform/module-structure/), [DI](https://vrallev.github.io/app-platform/di/), [renderers](https://vrallev.github.io/app-platform/renderer/), [templates](https://vrallev.github.io/app-platform/template/), and [testing](https://vrallev.github.io/app-platform/testing/).

--- a/skills/app-platform-presenters/agents/openai.yaml
+++ b/skills/app-platform-presenters/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Platform Presenters"
+  short_description: "Build presenters and select templates"
+  default_prompt: "Use $app-platform-presenters to build or update presenters, including models, state, template selection or delegation, tests, and setup."

--- a/skills/app-platform-renderers/SKILL.md
+++ b/skills/app-platform-renderers/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: app-platform-renderers
+description: Build and test App Platform renderers and template layouts. Use for Compose or Android View rendering, model bindings, child renderers, template layout or rendering, UI state, and renderer factory setup.
+---
+
+# App Platform Renderers and Template Layouts
+
+A `Renderer` turns a presenter's `BaseModel` into UI and sends user actions back through model callbacks. Add a renderer when a model needs direct visual output. A presenter that only selects child models may use their renderers directly.
+
+Follow the consuming app's UI toolkit, design system, source sets, and DI setup. App Platform supplies Compose Multiplatform and Android View renderers; preserve any app-specific native integration. Check the project's version before using experimental APIs. Examples omit imports; resolve unfamiliar APIs from existing code or matching public docs.
+
+## Keep responsibilities clear
+
+- Renderers own layout, localized text, animations, focus, and other UI details. Presenters own feature decisions, validation, and navigation state.
+- Read models without mutating them and forward events through their callbacks. Keep repositories and business logic in presenters.
+- Keep shared presenter APIs free of UI and platform types. When using App Platform's module layout, put renderers in `:impl`, with shared Compose UI in `commonMain` and platform code in its target source set.
+- Use the app's theme and components. Store UI labels in its localization resources; for Compose Multiplatform, these usually live under `src/commonMain/composeResources/values/strings.xml`. User-entered text and data from services can come from models. Test tags can be code constants.
+
+## Compose renderers
+
+Extend `ComposeRenderer<ModelT>` and override `Compose(model, modifier)`. Apply the supplied modifier to the root composable so parent layout, accessibility, input, and test behavior reach the UI.
+
+For a `ProfilePresenter.Model` with `displayName: String` and `onSelected: () -> Unit`:
+
+```kotlin
+@ContributesRenderer
+class ProfileRenderer : ComposeRenderer<ProfilePresenter.Model>() {
+  @Composable
+  override fun Compose(model: ProfilePresenter.Model, modifier: Modifier) {
+    BasicText(
+      text = model.displayName,
+      modifier = modifier.clickable(role = Role.Button, onClick = model.onSelected),
+    )
+  }
+}
+```
+
+Call `renderCompose(model, modifier)` from a composable context. The base `render(model)` entry point is unsupported for a direct `ComposeRenderer`.
+
+Keep UI state inside `Compose()` with `remember` or the appropriate state helper. Factories cache renderer instances, so fields should hold dependencies rather than per-screen Compose state. Read the current model on each call. For long-lived effects, use keys or `rememberUpdatedState` to keep callbacks current. Clean up UI listeners with `DisposableEffect`.
+
+## Registration and factories
+
+Annotate renderers with `@ContributesRenderer` and keep their classes public for generated code across modules. The renderer's model type determines its binding. With Metro, a single constructor gets a generated provider; `@Inject` is only needed to select among multiple constructors for this lookup.
+
+Create and keep a factory once per UI host, such as an activity, view controller, or window:
+
+| UI in the host | Factory |
+| --- | --- |
+| Compose Multiplatform | `ComposeRendererFactory` |
+| Android Views | `AndroidRendererFactory` |
+| Compose and Android Views together | `ComposeAndroidRendererFactory` |
+
+The Android factories hold an activity and parent view; keep them within that host's lifetime. `getRenderer()` and `getComposeRenderer()` reuse cached instances. Use `createRenderer()`, `createComposeRenderer()`, or a distinct `rendererId` when separate instances are needed.
+
+For missing-renderer errors, check the actual model type, contribution generation, the app's implementation dependencies, and the chosen factory. Confirm that the real host graph can resolve the renderer and its dependencies.
+
+## Child renderers
+
+Inject `RendererFactory` to render child models without depending on concrete child renderers. For a `PagePresenter.Model` with `content: BaseModel`:
+
+```kotlin
+@ContributesRenderer
+class PageRenderer(
+  private val rendererFactory: RendererFactory,
+) : ComposeRenderer<PagePresenter.Model>() {
+  @Composable
+  override fun Compose(model: PagePresenter.Model, modifier: Modifier) {
+    Box(modifier = modifier) {
+      rendererFactory.getComposeRenderer(model.content).renderCompose(model.content)
+    }
+  }
+}
+```
+
+Always pass the current child model. In repeated Compose content, key children by stable item identity so remembered UI state follows the right item.
+
+## Template rendering
+
+Templates are app-specific root models selected by the presenter tree. Use the `app-platform-presenters` skill for the template contract, root wrapper, `toTemplate`, and `ModelDelegate`. This section assumes variants such as `AppTemplate.FullScreen(content)` and `AppTemplate.ListDetail(list, detail)`.
+
+The template renderer lays out the semantic slots and resolves every current child model through `RendererFactory`. Follow the app's existing structure for root chrome, insets, and transitions:
+
+```kotlin
+@ContributesRenderer
+class AppTemplateRenderer(
+  private val rendererFactory: RendererFactory,
+) : ComposeRenderer<AppTemplate>() {
+  @Composable
+  override fun Compose(model: AppTemplate, modifier: Modifier) {
+    Box(modifier = modifier) {
+      when (model) {
+        is AppTemplate.FullScreen -> Render(model.content)
+        is AppTemplate.ListDetail -> Row {
+          Render(model.list, Modifier.weight(1f))
+          Render(model.detail, Modifier.weight(2f))
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun Render(model: BaseModel, modifier: Modifier = Modifier) {
+    rendererFactory.getComposeRenderer(model).renderCompose(model, modifier)
+  }
+}
+```
+
+`@ContributesRenderer` includes sealed subtypes by default, so one renderer can handle the whole template hierarchy. Add a renderer branch when adding a variant. Use distinct renderer IDs only when live slots need separate cached renderer instances.
+
+Templates use the normal rendering pipeline. Keep one renderer factory for the host lifetime and render each current template through it:
+
+```kotlin
+val template by templates.collectAsState()
+rendererFactory.getComposeRenderer(template).renderCompose(template)
+```
+
+With App Platform's module structure, put template renderers in `:impl` and platform-specific renderers in their target source sets. Keep renderer factory construction and implementation selection at app assembly.
+
+For Android Views, use `AndroidTemplateRenderer` and its `Container` for slots backed by real `ViewGroup`s. Reset inactive containers when the template changes so stale views are removed.
+
+## Backstacks
+
+For the experimental Navigation 3 integration, extend `PresenterBackstackRenderer<ModelT>` and implement `ComposeBackstackEntry()` using the same factory pattern. The base renderer forwards `model.onBack` and keeps popped models available for exit transitions. If overriding `PresenterNavDisplay()`, forward its `backstack`, `onBack`, `entryProvider`, and `modifier` to `NavDisplay`. Keep stack changes in presenter code.
+
+## Text input
+
+Keep cursor, selection, and IME composition in the UI while the presenter owns the text used by feature logic. Preserve the app's text synchronization contract.
+
+When integrating an existing `PresenterTextFieldState`, use App Platform's experimental `rememberPresenterBackedTextFieldState()` from `software.ralf.app.platform.renderer.text`. It returns Compose Foundation's `TextFieldState`:
+
+```kotlin
+@OptIn(ExperimentalAppPlatform::class)
+@Composable
+fun SearchField(presenterState: PresenterTextFieldState, modifier: Modifier) {
+  val fieldState = rememberPresenterBackedTextFieldState(presenterState)
+  BasicTextField(state = fieldState, modifier = modifier)
+}
+```
+
+Read `fieldState.text` for immediate UI feedback such as clear-button visibility. The helper copies edits in both directions; presenter text replacements place the cursor at the end.
+
+## Android Views
+
+Use `ViewRenderer<ModelT>` or an existing subtype such as `ViewBindingRenderer`. Create views in `inflate()`, bind the latest model and callbacks in `renderModel()`, and clean up registrations in `onDetach()`. View references belong to that renderer's view lifetime.
+
+Pass the actual parent `ViewGroup` when asking the factory for child renderers. The Android factory uses the parent in its cache key so different containers receive separate renderer instances. Use `ComposeAndroidRendererFactory` for View/Compose interop.
+
+## Build setup
+
+Configure each module that declares or hosts Compose UI through the app's conventions or public plugin:
+
+```kotlin
+plugins {
+  id("software.ralf.app.platform")
+}
+
+appPlatform {
+  enableComposeUi(true)
+}
+```
+
+This supplies Compose compiler/runtime, Foundation, and the Compose renderer API. Check existing conventions before adding dependencies. Add the app's chosen component library and UI test dependencies as needed; enabling Compose UI does not choose a design system.
+
+For Android View renderers, `addPublicModuleDependencies(true)` supplies the renderer APIs alongside the app's Android plugin setup.
+
+For Metro-generated contributions, use `enableMetro(true)`. Add implementation dependencies at app assembly points, using `addImplModuleDependencies(true)` when relying on App Platform defaults. Enable `enableMoleculePresenterBackstack(true)` for the Navigation 3 backstack module; it also enables Molecule presenters and Compose UI.
+
+## Tests
+
+Dedicated renderer tests are optional. Follow the app's existing test strategy, including screenshot tests for visual output. When extra behavior coverage is useful, use sample models and fake dependencies. Keep feature decisions in presenter tests.
+
+Prefer Desktop for shared Compose interaction tests when the project already has that target. Put them in `desktopTest` and use the app's runner, theme, and resource setup. For example:
+
+```kotlin
+@OptIn(ExperimentalTestApi::class)
+class ProfileRendererTest {
+  @Test
+  fun clickSelectsProfile() = runComposeUiTest {
+    var selected = false
+    val renderer = ProfileRenderer()
+    val model = ProfilePresenter.Model(displayName = "Ada", onSelected = { selected = true })
+
+    setContent {
+      renderer.renderCompose(model, Modifier.testTag("profile"))
+    }
+
+    onNodeWithTag("profile").assertTextEquals("Ada").performClick()
+    runOnIdle { assertTrue(selected) }
+  }
+}
+```
+
+Resolve `runComposeUiTest` from the project's UI test API; current App Platform examples use `androidx.compose.ui.test.v2`. Android interaction tests need their own setup, typically instrumentation on a device or emulator. Move tests into a shared source set only when all receiving targets already have compatible UI test support.
+
+Optional renderer or screenshot tests can cover each template variant, slot layout, app chrome, and transitions. When registration changes, a host integration test with the real factory can verify template and child renderer discovery. Use Desktop tests for shared Compose and window sizes, and Android instrumentation for activities, back handling, Views, or Compose/View interop.
+
+When writing interaction tests, useful checks include model and callback updates, text selection and presenter replacements, back events, and exit transitions. Use UI test synchronization instead of sleeps, and run the app's existing checks.
+
+Public docs: [renderers](https://vrallev.github.io/app-platform/renderer/), [templates](https://vrallev.github.io/app-platform/template/), [text fields](https://vrallev.github.io/app-platform/presenter/#presenter-backed-text-fields), [backstack](https://vrallev.github.io/app-platform/presenter/#presenter-backstack), [setup](https://vrallev.github.io/app-platform/setup/), and [testing](https://vrallev.github.io/app-platform/testing/).

--- a/skills/app-platform-renderers/agents/openai.yaml
+++ b/skills/app-platform-renderers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Platform Renderers and Template Layouts"
+  short_description: "Build renderers and template layouts"
+  default_prompt: "Use $app-platform-renderers to build or update renderers and template layouts, including model bindings, child rendering, UI state, factory setup, and tests."

--- a/skills/app-platform-scope/SKILL.md
+++ b/skills/app-platform-scope/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: app-platform-scope
+description: Manage App Platform scopes, coroutine lifetimes, and Metro graph integration. Use when creating root or child scopes, registering Scoped services, attaching CoroutineScopeScoped owners, connecting Metro graphs to scopes, or testing teardown.
+---
+
+# App Platform Scopes
+
+An App Platform `Scope` is an app-owned logical lifetime. It owns child scopes, lifecycle callbacks, and framework services, and can own coroutine cancellation. It works with or without dependency injection.
+
+Follow the consuming project's App Platform version, module layout, and DI setup. Examples omit imports; resolve unfamiliar APIs from existing code or matching public docs.
+
+## App Platform `Scope`
+
+Before creating a scope, identify what owns it, what starts and ends it, and which shorter lifetimes are its children. One owner should create the scope, destroy it, and release its reference.
+
+Create the root with `Scope.buildRootScope()` and shorter lifetimes with `buildChild()`:
+
+```kotlin
+val appScope = Scope.buildRootScope("app")
+val sessionScope = appScope.buildChild("session-$sessionId")
+
+sessionScope.destroy()
+appScope.destroy()
+```
+
+A child cannot outlive its parent. Destroying a parent destroys all children first. Do not keep a child scope, its graph, or its objects in a longer-lived owner. Most operations on a destroyed scope fail; use `isDestroyed()` to guard stale references and update related state in a deliberate order.
+
+Expose the app scope through `RootScopeProvider` when platform entry points or longer-lived coordinators need it. Keep scope owners small. Use the scope service map for App Platform integrations with typed helpers; use DI for application dependencies.
+
+### Lifecycle callbacks
+
+Implement `Scoped` on concrete services that need start or cleanup callbacks. Keep it out of their public interfaces:
+
+```kotlin
+class EventObserver(
+  private val events: Events,
+  private val onEvent: (Event) -> Unit,
+) : Scoped {
+  private var registration: Registration? = null
+
+  override fun onEnterScope(scope: Scope) {
+    registration = events.observe(onEvent)
+  }
+
+  override fun onExitScope() {
+    registration?.close()
+    registration = null
+  }
+}
+
+scope.register(EventObserver(events) { /* Handle the event. */ })
+```
+
+`register()` calls `onEnterScope()` immediately. `destroy()` later calls `onExitScope()`. Use `scope.onExit { ... }` for a small resource created locally.
+
+Callbacks have no thread guarantee. Keep `onExitScope()` synchronous and blocking. Do not depend on callback order between ordinary `Scoped` objects. A crash or process death does not call `onExitScope()`, so save durable state earlier.
+
+## Coroutine scopes
+
+Attach one `CoroutineScopeScoped` to every App Platform scope that runs coroutine work. Coroutine services are local: a child App Platform scope does not inherit its parent's coroutine owner.
+
+```kotlin
+val coroutineOwner = CoroutineScopeScoped(
+  ioDispatcher + SupervisorJob() + CoroutineName("SessionScope")
+)
+
+val sessionScope = appScope.buildChild("session-$sessionId") {
+  addCoroutineScopeScoped(coroutineOwner)
+}
+
+sessionScope.launch {
+  repository.sync()
+}
+
+val uploadScope = sessionScope.coroutineScope(CoroutineName("Upload"))
+```
+
+`CoroutineScopeScoped` needs a `CoroutineName` and an owning job. `addCoroutineScopeScoped()` stores and registers it. Destroying the App Platform scope cancels it.
+
+`scope.launch()` and `scope.coroutineScope()` create child coroutine scopes.
+
+Teardown runs in this order:
+
+1. Child App Platform scopes are destroyed.
+2. Registered `CoroutineScopeScoped` owners are canceled.
+3. Other `Scoped` objects receive `onExitScope()`.
+
+Start long-running work with `scope.launch` in `onEnterScope()`. By `onExitScope()`, the coroutine owner has already been canceled; use that callback only for synchronous cleanup.
+
+## Metro object graphs and App Platform integration
+
+A Metro scope key and an App Platform `Scope` are separate. Metro controls object reuse inside a graph. App Platform controls the logical lifetime and teardown. The scope owner must align them.
+
+Enable Metro through the consuming project's App Platform plugin:
+
+```kotlin
+appPlatform {
+  enableMetro(true)
+}
+```
+
+Build final graphs at the app assembly boundary, often in platform source sets when they need platform values. Match one graph lifetime to one App Platform scope lifetime.
+
+### Attach and register a graph
+
+The graph must expose its App Platform lifecycle set and coroutine owner. The names can follow the project:
+
+```kotlin
+@ContributesTo(AppScope::class)
+interface AppGraph {
+  @ForScope(AppScope::class)
+  @Multibinds(allowEmpty = true)
+  val scopedInstances: Set<Scoped>
+
+  @ForScope(AppScope::class)
+  val coroutineOwner: CoroutineScopeScoped
+}
+```
+
+Attach the graph and coroutine owner while building the App Platform scope. Publish the scope before registering lifecycle objects, because `register()` invokes callbacks immediately:
+
+```kotlin
+class AppScopeOwner : RootScopeProvider {
+  private var currentScope: Scope? = null
+
+  override val rootScope: Scope
+    get() = checkNotNull(currentScope)
+
+  fun start(graph: AppGraph) {
+    check(currentScope == null)
+
+    val scope = Scope.buildRootScope("app") {
+      addMetroDependencyGraph(graph)
+      addCoroutineScopeScoped(graph.coroutineOwner)
+    }
+    currentScope = scope
+    scope.register(graph.scopedInstances)
+  }
+
+  fun close() {
+    val scope = currentScope ?: return
+    scope.destroy()
+    currentScope = null
+  }
+}
+```
+
+Metro creates `Scoped` objects but does not register them with App Platform. Repeat this sequence for custom child graphs: create the graph, build and publish its child `Scope`, attach its graph and coroutine owner, then register its `Set<Scoped>`.
+
+The scope builder has one Metro graph service slot. If it receives more than one graph while building, it keeps the last, so the final graph should expose every narrow graph surface needed for that lifetime.
+
+`scope.metroDependencyGraph<T>()` checks the current scope and then its parents. It never checks children. Prefer constructor injection within the graph; use graph lookup at platform-created entry points and scope boundaries.
+
+## App Platform Metro features
+
+At app assembly points, `addImplModuleDependencies(true)` adds App Platform's default Metro bindings:
+
+- IO, default, and main coroutine dispatchers.
+- The `AppScope` `CoroutineScopeScoped` and fresh child `CoroutineScope` values.
+- `@PresenterCoroutineScope`, based on the app scope and main dispatcher.
+
+The root owner must still install the graph's coroutine owner with `addCoroutineScopeScoped()`. Custom child graphs need their own qualified owner and injectable children:
+
+```kotlin
+@Provides
+@SingleIn(SessionScope::class)
+@ForScope(SessionScope::class)
+fun provideCoroutineOwner(
+  @IoCoroutineDispatcher dispatcher: CoroutineDispatcher,
+): CoroutineScopeScoped {
+  return CoroutineScopeScoped(
+    dispatcher + SupervisorJob() + CoroutineName("SessionScope")
+  )
+}
+
+@Provides
+@ForScope(SessionScope::class)
+fun provideCoroutineScope(
+  @ForScope(SessionScope::class) owner: CoroutineScopeScoped,
+): CoroutineScope = owner.createChild()
+```
+
+Use App Platform's `@ContributesScoped` for a Metro-created lifecycle service. Pair it with `@SingleIn` for the same lifetime so injection and lifecycle registration use the same object:
+
+```kotlin
+interface SessionObserver
+
+@SingleIn(SessionScope::class)
+@ContributesScoped(SessionScope::class)
+class DefaultSessionObserver(
+  private val repository: SessionRepository,
+) : SessionObserver, Scoped
+```
+
+Do not also add `@ContributesBinding`. `@ContributesScoped` adds the qualified `Scoped` set entry. If the class has one direct supertype besides `Scoped`, it binds that type too. A contributed class may have at most one such supertype.
+
+App Platform's Metro compiler support also handles `@ContributesRenderer` and `@ContributesRobot`. Their factories own instance lifetimes, so do not make renderers or robots Metro singletons. Use their dedicated guidance for registration and factories. For generated contributions, one constructor needs no `@Inject`; when there are several, mark the selected constructor. Keep contributed classes public when graphs in other modules use them.
+
+Use Metro's documentation for graph factories, bindings, and aggregation. This skill covers only the App Platform integration.
+
+## Tests
+
+Prefer `runTestWithScope`. It adds a test-scheduler-backed coroutine owner and always destroys the scope:
+
+```kotlin
+@Test
+fun startsWork() = runTestWithScope { scope ->
+  val service = SessionService()
+  scope.register(service)
+
+  runCurrent()
+  // Assert behavior started by onEnterScope().
+}
+```
+
+Use `runTestWithScoped(service)` for one prebuilt lifecycle service. Use `Scope.buildTestScope(this)` inside an existing `runTest`. Drive coroutine work with the test scheduler instead of sleeps.
+
+Test scopes already have a coroutine owner; do not attach a second one. For graph integration, exercise the production scope owner with a test-dispatcher-backed graph so graph attachment, registration, and teardown run together.
+
+Compile the final app graph and affected targets after changing contributed lifecycle services. A feature-module compile alone does not verify graph assembly.
+
+Public docs: [scopes](https://vrallev.github.io/app-platform/scope/), [DI](https://vrallev.github.io/app-platform/di/), [renderers](https://vrallev.github.io/app-platform/renderer/), [setup](https://vrallev.github.io/app-platform/setup/), [module structure](https://vrallev.github.io/app-platform/module-structure/), and [testing](https://vrallev.github.io/app-platform/testing/). Use the [Metro documentation](https://zacsweers.github.io/metro/latest/) for Metro APIs.

--- a/skills/app-platform-scope/agents/openai.yaml
+++ b/skills/app-platform-scope/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Platform Scopes"
+  short_description: "Manage App Platform scopes and lifetimes"
+  default_prompt: "Use $app-platform-scope to build App Platform scope lifecycles, coroutine scopes, and Metro graph integration."

--- a/skills/app-platform-testing/SKILL.md
+++ b/skills/app-platform-testing/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: app-platform-testing
+description: Test applications built with App Platform. Use for shared fakes, Kotlin Multiplatform unit tests, coroutine and Flow tests, presenter or scope tests, optional Desktop renderer tests, robot modules, and platform integration tests.
+---
+
+# App Platform Testing
+
+Use the smallest test that proves the behavior. Keep most feature logic in fast shared tests, and use app integration tests for graph assembly, host lifecycle, platform rendering, and full user journeys.
+
+Follow the consuming project's targets, assertion library, UI test runner, screenshot setup, and DI choice. Examples omit imports and use AssertK for value assertions; resolve unfamiliar APIs from existing code or matching public docs.
+
+## Choose the test layer
+
+| Concern | Default test | Usual location |
+| --- | --- | --- |
+| Shared logic, repositories, presenters, and model changes | Unit test | `commonTest` |
+| App Platform scope lifecycle | Unit test with a test scope | `commonTest` |
+| Model-to-UI rendering | Optional renderer or screenshot test | Desktop or another supported UI test source set |
+| Full graph behavior without visual checks | Headless integration test | Test-only app assembly |
+| Launch, rendering, platform lifecycle, and user journeys | Robot integration test | Platform app test source set |
+
+Put platform behavior in its platform test source set. Keep app-shell tests focused on app-shell wiring. Name tests after product behavior or screens; include a platform name only when the behavior is platform-specific. Do not repeat the same presenter or repository behavior at every layer.
+
+## Fakes
+
+Use a real implementation when it is fast, deterministic, and easy to construct. Otherwise prefer a fake over a mocking framework. Search the repository before adding another fake.
+
+Put a reusable fake in the API owner's `:testing` module, usually in `commonMain`. Keep a one-off fake beside its test. Ordinary production modules add `:testing` only to test configurations; a test-only `:testing` or robot assembly module may use it from its main source set.
+
+Give fakes clear controls and observable results. Keep them deterministic, return valid domain data, and support the failures or delays that consumers handle. Avoid mock-style call scripts that copy implementation details. Reset shared fake state between tests when a test graph outlives one test.
+
+```kotlin
+class FakeLocationProvider(
+  initialLocation: Location,
+) : LocationProvider {
+  override val location: StateFlow<Location>
+    field = MutableStateFlow(initialLocation)
+
+  fun setLocation(value: Location) {
+    location.value = value
+  }
+}
+```
+
+## Unit tests
+
+Construct the unit directly with real values and fakes. Drive its public inputs and assert its public outputs instead of private calls or collaborator call order.
+
+Use `runTest` for coroutine code and its scheduler for delays. Use Turbine when a `Flow` changes over time. Do not use wall-clock sleeps.
+
+```kotlin
+@Test
+fun routeChangesWithLocation() = runTest {
+  val locations = FakeLocationProvider(start)
+  val repository = RoutingRepository(locations)
+
+  repository.route.test {
+    assertThat(awaitItem()).isEqualTo(startRoute)
+
+    locations.setLocation(destination)
+    assertThat(awaitItem()).isEqualTo(destinationRoute)
+  }
+}
+```
+
+For `MoleculePresenter`, pass the current `TestScope` to the App Platform `test` helper. Drive changes through model callbacks, input flows, or fakes. For a counter model with `count` and `onIncrement`:
+
+```kotlin
+@Test
+fun incrementUpdatesTheModel() = runTest {
+  CounterPresenter().test(this) {
+    val initial = awaitItem()
+    assertThat(initial.count).isEqualTo(0)
+
+    initial.onIncrement()
+    assertThat(awaitItem().count).isEqualTo(1)
+  }
+}
+```
+
+For `Scoped` services, prefer `runTestWithScope` or `runTestWithScoped`. Use `Scope.buildTestScope(this)` when an existing `runTest` owns the scheduler. These helpers install a test coroutine owner and clean up the App Platform scope; do not attach a second coroutine owner.
+
+## Optional renderer tests
+
+Dedicated renderer tests are optional. Keep the app's screenshot strategy when it already covers the same visual states. When a Desktop target exists, `runComposeUiTest` is usually the quickest way to render immutable sample models and check meaningful branches or callbacks:
+
+```kotlin
+@OptIn(ExperimentalTestApi::class)
+@Test
+fun showsProgress() = runComposeUiTest {
+  setContent {
+    LoginRenderer().renderCompose(
+      LoginPresenter.Model(loginInProgress = true) {},
+    )
+  }
+
+  onNodeWithTag("loginProgress").assertIsDisplayed()
+}
+```
+
+Use `desktopTest` or a shared source set only when every receiving target has compatible UI test support. Android renderer tests that need Android runtime behavior require instrumentation on a device or emulator.
+
+## Robots
+
+Robots expose product actions and observations while hiding tags, labels, test framework calls, fake internals, and platform input APIs. They can interact with UI, control fake scenarios, inspect analytics, or wrap system actions such as back navigation.
+
+Put reusable feature robots in a robot module, usually `:impl-robots`. Put app-level journeys, test graph assembly, and shared fixtures in a test-only app assembly when several tests need them. Keep robot modules off production runtime classpaths.
+
+Annotate discoverable robots with `@ContributesRobot` using the consuming graph's scope key. Keep contributed classes public when generated graphs in other modules use them. Use `ComposeRobot` with `composeRobot<T>()`; use plain `Robot` or `AndroidViewRobot` with `robot<T>()`.
+
+```kotlin
+@ContributesRobot(AppScope::class)
+class SignInRobot(
+  private val scenario: FakeSignInScenario,
+) : ComposeRobot() {
+  fun failNextSignIn() {
+    scenario.failNext()
+  }
+
+  fun signIn() {
+    compose.onNodeWithTag("signIn").performClick()
+  }
+
+  fun seeError() {
+    compose.onNodeWithTag("signInError").assertIsDisplayed()
+  }
+}
+```
+
+Each `robot<T>()` or `composeRobot<T>()` call creates a fresh instance and calls `close()` afterward. Keep shared scenario state in an injected fake or scoped state owner, and do not make robots singletons. Robot lookup starts at the root scope and searches children; the same robot type in multiple sibling scopes is ambiguous.
+
+Prefer stable semantics tags and keep selectors inside robots. Move repeated action sequences into named product journeys. Share a journey in `commonMain` when the same behavior is intentionally tested on several hosts, and call it from every intended host suite. Otherwise share the robot vocabulary and keep the scenario platform-specific.
+
+## Robot integration tests
+
+Reuse or extend the app's existing UI test rule or fixture before adding setup. It should build a fresh, production-backed test graph, replace external systems with fakes, start the real root presenter and template path, and render through the real factory. If the behavior can be proved from the template or model stream, use a headless fixture and skip rendering.
+
+Keep platform test classes thin:
+
+```kotlin
+@Test
+fun failedSignInShowsAnError() = runRobotTest {
+  composeRobot<SignInRobot> {
+    failNextSignIn()
+    signIn()
+  }
+
+  waitUntilCatching("sign-in error shown") {
+    composeRobot<SignInRobot> { seeError() }
+  }
+}
+```
+
+`runRobotTest` in this example is an app-owned fixture. It should launch the host, make its `RootScopeProvider` available to robot lookup, render the root template when needed, and always tear everything down. Desktop and other hosts without automatic application lookup use the matching `RobotInternals` API for their App Platform version; clear it afterward. Android normally obtains the root scope from the test application. Destroy the app or root scope after every test.
+
+Use UI test synchronization and App Platform wait helpers instead of sleeps. `waitUntilCatching` retries its whole block and blocks the calling thread, so call it off the main thread and put only repeatable observations inside it. Perform clicks and other actions once, outside retry blocks.
+
+Hide platform-only actions behind robot facades when several hosts share a journey. Keep launch rules, device setup, and native host behavior in their platform source sets.
+
+## Build setup
+
+The App Platform plugin recognizes robot module names and adds the base Robot API. Modules with Compose robots also need the project's Compose UI option:
+
+```kotlin
+appPlatform {
+  enableComposeUi(true)
+}
+```
+
+Keep `enableModuleStructure(true)` when the project uses App Platform's `:testing` and robot module rules. Keep the project's existing DI integration enabled so `@ContributesRobot` registrations are generated. `enableComposeUi(true)` supplies Compose Robot support, but the app still chooses its UI test runner and screenshot dependencies. `enableMoleculePresenters(true)` supplies the presenter test helper to test source sets, and the public plugin supplies scope test helpers.
+
+Ordinary production modules add `:testing` only to test configurations and robot modules only to UI or integration-test configurations. Test-only `:testing` and robot modules may use `:testing` from main source sets; robot modules may also depend on other robot modules. Compile the final test graph after changing robot contributions or test bindings; compiling the feature alone does not verify graph assembly.
+
+## Run checks
+
+Run the narrowest configured task first, then the platform suites affected by the change.
+
+- KMP libraries often use `testAndroidHostTest`, `desktopTest`, `iosSimulatorArm64Test`, or `allTests`. Inspect the module's targets before choosing.
+- `testDebugUnitTest` is usually an Android app-shell task, not the default for a KMP library.
+- Use the Desktop app's `desktopTest` for rendered Desktop journeys.
+- Use `connectedDebugAndroidTest` or the project's managed-device task for Android activities, Views, back handling, or Compose/View integration.
+- Run `checkModuleStructureDependencies` after adding or changing `:testing` or robot dependencies.
+
+Public docs: [testing](https://vrallev.github.io/app-platform/testing/), [module structure](https://vrallev.github.io/app-platform/module-structure/), [presenters](https://vrallev.github.io/app-platform/presenter/), [renderers](https://vrallev.github.io/app-platform/renderer/), and [scopes](https://vrallev.github.io/app-platform/scope/).

--- a/skills/app-platform-testing/agents/openai.yaml
+++ b/skills/app-platform-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Platform Testing"
+  short_description: "Test App Platform applications"
+  default_prompt: "Use $app-platform-testing to add or update fakes, unit tests, renderer tests, and robot integration tests."


### PR DESCRIPTION
Give coding agents reusable guidance for App Platform module boundaries, scopes, `MoleculePresenter` hierarchies, renderers, templates, and testing without tying the instructions to one application. Link the skills from the setup guide so consumers can select focused guidance for each change.
