### PR TITLE
Use Metro compiler-compat for broader compiler compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,36 @@ jobs:
           name: test-results-${{ github.job }}
           path: ./**/build/reports/
 
+  test-metro-compiler-compatibility:
+    name: test-metro-compiler-compatibility / Kotlin ${{ matrix.kotlin }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    strategy:
+      fail-fast: false
+      matrix:
+        kotlin: ['2.4.0', '2.4.10', '2.4.20-RC3']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup-action
+        with:
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      # Dump and diagnostic goldens remain tied to the repository's pinned compiler version.
+      - name: Test
+        run: ./gradlew :metro-extensions:contribute:impl-compiler-plugin:test -PkotlinVersion=${{ matrix.kotlin }} --tests 'software.ralf.app.platform.metro.compiler.runners.BoxTestGenerated*' --stacktrace --show-version
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: test-results-${{ github.job }}-${{ matrix.kotlin }}
+          path: ./**/build/reports/
+
   test-emulator-renderer-android-view:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Make the Metro compiler extension more resilient to Kotlin compiler upgrades by using Metro's compiler compat APIs.
+
 ### Deprecated
 
 ### Removed

--- a/metro-extensions/contribute/impl-compiler-plugin/build.gradle
+++ b/metro-extensions/contribute/impl-compiler-plugin/build.gradle
@@ -17,6 +17,20 @@ configurations {
     }
 }
 
+def testKotlinVersion =
+        providers.gradleProperty('kotlinVersion').orElse(libs.versions.kotlin.asProvider())
+
+configurations
+        .matching { it.name in ['testCompileClasspath', 'testRuntimeClasspath'] }
+        .configureEach {
+            resolutionStrategy.eachDependency { details ->
+                if (details.requested.group == 'org.jetbrains.kotlin') {
+                    details.useVersion(testKotlinVersion.get())
+                    details.because('The compiler compatibility tests must use one Kotlin version')
+                }
+            }
+        }
+
 dependencies {
     compileOnly libs.kotlin.compiler.embeddable
     compileOnly libs.metro.compiler

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/AppPlatformMetroExtensionsPluginComponentRegistrar.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/AppPlatformMetroExtensionsPluginComponentRegistrar.kt
@@ -1,10 +1,9 @@
 package software.ralf.app.platform.metro.compiler
 
 import com.google.auto.service.AutoService
-import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import software.ralf.app.platform.metro.compiler.renderer.ContributesRendererIrExtension
 import software.ralf.app.platform.metro.compiler.robot.ContributesRobotIrExtension
 import software.ralf.app.platform.metro.compiler.scoped.ContributesScopedIrExtension
@@ -15,9 +14,23 @@ public class AppPlatformMetroExtensionsPluginComponentRegistrar : CompilerPlugin
   override val supportsK2: Boolean = true
 
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-    FirExtensionRegistrarAdapter.registerExtension(AppPlatformMetroExtensionsPluginRegistrar())
-    IrGenerationExtension.registerExtension(ContributesRendererIrExtension())
-    IrGenerationExtension.registerExtension(ContributesRobotIrExtension())
-    IrGenerationExtension.registerExtension(ContributesScopedIrExtension())
+    val compatContext =
+      try {
+        CompatContext.create()
+      } catch (throwable: Throwable) {
+        System.err.println(
+          "[APP PLATFORM] Unable to load Kotlin compiler compatibility support; " +
+            "skipping compiler extensions."
+        )
+        throwable.printStackTrace()
+        return
+      }
+
+    with(compatContext) {
+      registerFirExtensionCompat(AppPlatformMetroExtensionsPluginRegistrar())
+      registerIrExtensionCompat(ContributesRendererIrExtension(compatContext))
+      registerIrExtensionCompat(ContributesRobotIrExtension())
+      registerIrExtensionCompat(ContributesScopedIrExtension())
+    }
   }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/fir/FirHelpers.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/fir/FirHelpers.kt
@@ -1,5 +1,6 @@
 package software.ralf.app.platform.metro.compiler.fir
 
+import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
@@ -20,7 +21,6 @@ import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.expressions.buildResolvedArgumentList
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
 import org.jetbrains.kotlin.fir.expressions.builder.buildGetClassCall
-import org.jetbrains.kotlin.fir.expressions.builder.buildResolvedQualifier
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLikeLookupTagImpl
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
@@ -200,22 +201,14 @@ internal fun resolveClassReferenceArgument(
   val innerArgument = getClassCall.argumentList.arguments.firstOrNull() ?: return null
 
   return when (innerArgument) {
-    is FirResolvedQualifier ->
-      innerArgument.classId?.let { classId ->
-        ResolvedClassReference(
-          classId = classId,
-          classSymbol =
-            (innerArgument.symbol as? FirRegularClassSymbol)
-              ?: (session.symbolProvider.getClassLikeSymbolByClassId(classId)
-                as? FirRegularClassSymbol)
-              ?: findClassLikeSymbolInContainingFile(classSymbol, classId, session)
-              ?: findClassLikeSymbolInPackageFiles(
-                classSymbol.classId.packageFqName,
-                classId,
-                session,
-              ),
-        )
-      }
+    is FirResolvedQualifier -> {
+      val relativeClassFqName = innerArgument.relativeClassFqName ?: return null
+      val classId = ClassId(innerArgument.packageFqName, relativeClassFqName, isLocal = false)
+      ResolvedClassReference(
+        classId = classId,
+        classSymbol = findRegularClassSymbol(classId, classSymbol, session),
+      )
+    }
 
     is FirPropertyAccessExpression -> {
       val reference = innerArgument.calleeReference
@@ -256,24 +249,11 @@ internal fun resolveClassReferenceArgument(
             .plus(explicitImportClassIds.asSequence())
             .plus(allUnderImportClassIds.asSequence())
             .firstOrNull { candidateClassId ->
-              session.symbolProvider.getClassLikeSymbolByClassId(candidateClassId) != null ||
-                findClassLikeSymbolInContainingFile(classSymbol, candidateClassId, session) !=
-                  null ||
-                findClassLikeSymbolInPackageFiles(
-                  classSymbol.classId.packageFqName,
-                  candidateClassId,
-                  session,
-                ) != null
+              findClassLikeSymbol(candidateClassId, classSymbol, session) != null
             } ?: samePackageClassId
         ResolvedClassReference(
           classId,
-          (session.symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol)
-            ?: findClassLikeSymbolInContainingFile(classSymbol, classId, session)
-            ?: findClassLikeSymbolInPackageFiles(
-              classSymbol.classId.packageFqName,
-              classId,
-              session,
-            ),
+          findRegularClassSymbol(classId, classSymbol, session),
         )
       }
     }
@@ -285,6 +265,7 @@ internal fun resolveClassReferenceArgument(
 internal fun buildClassExpression(
   classSymbol: FirClassSymbol<*>,
   session: FirSession,
+  compatContext: CompatContext,
 ): FirExpression {
   val classId = classSymbol.classId
   val classType =
@@ -303,14 +284,7 @@ internal fun buildClassExpression(
 
   return buildGetClassCall {
     coneTypeOrNull = kClassType
-    val qualifier = buildResolvedQualifier {
-      packageFqName = classId.packageFqName
-      relativeClassFqName = classId.relativeClassName
-      coneTypeOrNull = classType
-      symbol = classSymbol
-      resolvedToCompanionObject = false
-      isFullyQualified = true
-    }
+    val qualifier = compatContext.buildResolvedQualifierCompat(classId, classSymbol, classType)
     argumentList =
       buildResolvedArgumentList(
         original = null,
@@ -325,6 +299,7 @@ internal fun buildClassExpression(
 internal fun buildClassExpression(
   classId: ClassId,
   session: FirSession,
+  compatContext: CompatContext,
   ownerSymbol: FirRegularClassSymbol? = null,
 ): FirExpression {
   val classType =
@@ -342,22 +317,12 @@ internal fun buildClassExpression(
     )
 
   val classSymbol =
-    session.symbolProvider.getClassLikeSymbolByClassId(classId)
-      ?: ownerSymbol?.let { findClassLikeSymbolInContainingFile(it, classId, session) }
-      ?: ownerSymbol?.let {
-        findClassLikeSymbolInPackageFiles(it.classId.packageFqName, classId, session)
-      }
+    findClassLikeSymbol(classId, ownerSymbol, session)
+      ?: error("Unable to resolve $classId for generated class literal")
 
   return buildGetClassCall {
     coneTypeOrNull = kClassType
-    val qualifier = buildResolvedQualifier {
-      packageFqName = classId.packageFqName
-      relativeClassFqName = classId.relativeClassName
-      coneTypeOrNull = classType
-      symbol = classSymbol
-      resolvedToCompanionObject = false
-      isFullyQualified = classSymbol != null
-    }
+    val qualifier = compatContext.buildResolvedQualifierCompat(classId, classSymbol, classType)
     argumentList =
       buildResolvedArgumentList(
         original = null,
@@ -366,7 +331,7 @@ internal fun buildClassExpression(
             qualifier to
               buildSyntheticClassLiteralParameter(
                 classType = classType,
-                containingSymbol = classSymbol ?: ownerSymbol,
+                containingSymbol = classSymbol,
                 session = session,
               )
           ),
@@ -387,6 +352,32 @@ private fun buildSyntheticClassLiteralParameter(
   symbol = FirValueParameterSymbol()
   containingDeclarationSymbol =
     containingSymbol ?: error("Unable to determine containing symbol for generated class literal")
+}
+
+internal fun findRegularClassSymbol(
+  classId: ClassId,
+  ownerSymbol: FirRegularClassSymbol?,
+  session: FirSession,
+): FirRegularClassSymbol? =
+  findClassLikeSymbol(classId, ownerSymbol, session) as? FirRegularClassSymbol
+
+private fun findClassLikeSymbol(
+  classId: ClassId,
+  ownerSymbol: FirRegularClassSymbol?,
+  session: FirSession,
+): FirClassLikeSymbol<*>? {
+  val sessions = allSessions(session)
+  return sessions.firstNotNullOfOrNull { candidateSession ->
+    candidateSession.symbolProvider.getClassLikeSymbolByClassId(classId)
+  }
+    ?: ownerSymbol?.let { owner ->
+      sessions.firstNotNullOfOrNull { candidateSession ->
+        findClassLikeSymbolInContainingFile(owner, classId, candidateSession)
+      }
+    }
+    ?: sessions.firstNotNullOfOrNull { candidateSession ->
+      findClassLikeSymbolInPackageFiles(classId.packageFqName, classId, candidateSession)
+    }
 }
 
 @OptIn(DirectDeclarationsAccess::class)

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
@@ -103,8 +103,12 @@ import software.ralf.app.platform.metro.compiler.fir.resolveTypeRef
  * `includeSealedSubtypes` is enabled, the `Model` binding pair is generated once per collected
  * model subtype.
  */
-public class ContributesRendererFir(session: FirSession) :
-  MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+public class ContributesRendererFir
+internal constructor(
+  session: FirSession,
+  private val compatContext: CompatContext,
+) : MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+  public constructor(session: FirSession) : this(session, CompatContext.create())
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(ContributesRendererIds.PREDICATE)
@@ -520,7 +524,8 @@ public class ContributesRendererFir(session: FirSession) :
         ?: error("Annotation class ${ClassIds.CONTRIBUTES_TO} not found on the classpath")
     annotationTypeRef = contributesToSymbol.defaultType().toFirResolvedTypeRef()
     argumentMapping = buildAnnotationArgumentMapping {
-      mapping[Name.identifier("scope")] = buildClassExpression(ClassIds.RENDERER_SCOPE, session)
+      mapping[Name.identifier("scope")] =
+        buildClassExpression(ClassIds.RENDERER_SCOPE, session, compatContext)
     }
   }
 
@@ -528,7 +533,7 @@ public class ContributesRendererFir(session: FirSession) :
     buildAnnotationCallWithArgument(
       classId = ClassIds.FOR_SCOPE,
       argName = Name.identifier("scope"),
-      argument = buildClassExpression(ClassIds.RENDERER_SCOPE, session),
+      argument = buildClassExpression(ClassIds.RENDERER_SCOPE, session, compatContext),
       containingSymbol = containingSymbol,
       session = session,
     )
@@ -540,7 +545,7 @@ public class ContributesRendererFir(session: FirSession) :
     buildAnnotationCallWithArgument(
       classId = ClassIds.ORIGIN,
       argName = Name.identifier("value"),
-      argument = buildClassExpression(owner, session),
+      argument = buildClassExpression(owner, session, compatContext),
       containingSymbol = containingSymbol,
       session = session,
     )
@@ -554,8 +559,8 @@ public class ContributesRendererFir(session: FirSession) :
       classId = ClassIds.RENDERER_KEY,
       argName = Name.identifier("value"),
       argument =
-        modelClass.classSymbol?.let { buildClassExpression(it, session) }
-          ?: buildClassExpression(modelClass.classId, session, owner),
+        modelClass.classSymbol?.let { buildClassExpression(it, session, compatContext) }
+          ?: buildClassExpression(modelClass.classId, session, compatContext, owner),
       containingSymbol = containingSymbol,
       session = session,
     )
@@ -566,6 +571,6 @@ public class ContributesRendererFir(session: FirSession) :
       session: FirSession,
       options: MetroOptions,
       compatContext: CompatContext,
-    ): MetroFirDeclarationGenerationExtension = ContributesRendererFir(session)
+    ): MetroFirDeclarationGenerationExtension = ContributesRendererFir(session, compatContext)
   }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
@@ -1,5 +1,6 @@
 package software.ralf.app.platform.metro.compiler.renderer
 
+import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -26,6 +27,7 @@ import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.name.Name
 import software.ralf.app.platform.metro.compiler.ClassIds
 import software.ralf.app.platform.metro.compiler.Keys
 
@@ -64,16 +66,21 @@ import software.ralf.app.platform.metro.compiler.Keys
  * `@Binds` support.
  */
 @Suppress("DEPRECATION")
-internal class ContributesRendererIrExtension : IrGenerationExtension {
+internal class ContributesRendererIrExtension(private val compatContext: CompatContext) :
+  IrGenerationExtension {
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    moduleFragment.transformChildrenVoid(ContributesRendererIrTransformer(pluginContext))
+    moduleFragment.transformChildrenVoid(
+      ContributesRendererIrTransformer(pluginContext, compatContext)
+    )
   }
 }
 
 @Suppress("DEPRECATION")
 @OptIn(UnsafeDuringIrConstructionAPI::class)
-private class ContributesRendererIrTransformer(private val pluginContext: IrPluginContext) :
-  IrElementTransformerVoid() {
+private class ContributesRendererIrTransformer(
+  private val pluginContext: IrPluginContext,
+  private val compatContext: CompatContext,
+) : IrElementTransformerVoid() {
 
   override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
     val origin = declaration.origin
@@ -146,10 +153,16 @@ private class ContributesRendererIrTransformer(private val pluginContext: IrPlug
         parentClass
       }
     val originAnnotation =
-      contributionClass.annotations.firstOrNull { annotation ->
-        annotation.symbol.owner.parentAsClass.name == ClassIds.ORIGIN.shortClassName
+      with(compatContext) {
+        contributionClass.annotationsCompat().firstOrNull { annotation ->
+          annotation.symbol.owner.parentAsClass.name == ClassIds.ORIGIN.shortClassName
+        }
       } ?: return null
-    val classReference = originAnnotation.arguments[0] as? IrClassReference ?: return null
+    val classReference =
+      with(compatContext) {
+        originAnnotation.getAnnotationArgumentCompat(Name.identifier("value"))
+      }
+        as? IrClassReference ?: return null
     return classReference.classType.classOrNull?.owner
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererSupport.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/renderer/ContributesRendererSupport.kt
@@ -28,9 +28,8 @@ import org.jetbrains.kotlin.name.Name
 import software.ralf.app.platform.metro.compiler.ClassIds
 import software.ralf.app.platform.metro.compiler.fir.allSessions
 import software.ralf.app.platform.metro.compiler.fir.findAnnotation
-import software.ralf.app.platform.metro.compiler.fir.findClassLikeSymbolInContainingFile
-import software.ralf.app.platform.metro.compiler.fir.findClassLikeSymbolInPackageFiles
 import software.ralf.app.platform.metro.compiler.fir.findContainingFile
+import software.ralf.app.platform.metro.compiler.fir.findRegularClassSymbol
 import software.ralf.app.platform.metro.compiler.fir.hasAnnotation
 import software.ralf.app.platform.metro.compiler.fir.resolveClassIdArgument
 import software.ralf.app.platform.metro.compiler.fir.resolveClassReferenceArgument
@@ -173,15 +172,7 @@ private fun explicitRendererModelType(
     ?.takeIf { it.classId != ClassIds.UNIT }
     ?.let {
       val resolvedClassSymbol =
-        it.classSymbol
-          ?: (session.symbolProvider.getClassLikeSymbolByClassId(it.classId)
-            as? FirRegularClassSymbol)
-          ?: findClassLikeSymbolInContainingFile(classSymbol, it.classId, session)
-          ?: findClassLikeSymbolInPackageFiles(
-            classSymbol.classId.packageFqName,
-            it.classId,
-            session,
-          )
+        it.classSymbol ?: findRegularClassSymbol(it.classId, classSymbol, session)
       ResolvedModelClass(classId = it.classId, classSymbol = resolvedClassSymbol)
     }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/robot/ContributesRobotFir.kt
@@ -98,8 +98,12 @@ import software.ralf.app.platform.metro.compiler.fir.resolveTypeRef
  * No top-level graph interface is generated. If the robot class is already `@Inject`-constructible,
  * the nested declaration omits `provideTestRobot(...)` and only synthesizes the map-binding method.
  */
-public class ContributesRobotFir(session: FirSession) :
-  MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+public class ContributesRobotFir
+internal constructor(
+  session: FirSession,
+  private val compatContext: CompatContext,
+) : MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+  public constructor(session: FirSession) : this(session, CompatContext.create())
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(ContributesRobotIds.PREDICATE)
@@ -406,7 +410,7 @@ public class ContributesRobotFir(session: FirSession) :
       }
       annotations += buildSimpleAnnotationCall(ClassIds.BINDS, functionSymbol, session)
       annotations += buildSimpleAnnotationCall(ClassIds.INTO_MAP, functionSymbol, session)
-      annotations += buildRobotKeyAnnotation(owner.classId)
+      annotations += buildRobotKeyAnnotation(owner)
     }
   }
 
@@ -521,18 +525,18 @@ public class ContributesRobotFir(session: FirSession) :
         ?: error("Annotation class ${ClassIds.ORIGIN} not found on the classpath")
     annotationTypeRef = originSymbol.defaultType().toFirResolvedTypeRef()
     argumentMapping = buildAnnotationArgumentMapping {
-      mapping[Name.identifier("value")] = buildClassExpression(owner, session)
+      mapping[Name.identifier("value")] = buildClassExpression(owner, session, compatContext)
     }
   }
 
-  private fun buildRobotKeyAnnotation(robotClassId: ClassId) = buildAnnotation {
+  private fun buildRobotKeyAnnotation(robotClass: FirClassSymbol<*>) = buildAnnotation {
     val robotKeySymbol =
       session.symbolProvider.getClassLikeSymbolByClassId(ClassIds.ROBOT_KEY)
         as? FirRegularClassSymbol
         ?: error("Annotation class ${ClassIds.ROBOT_KEY} not found on the classpath")
     annotationTypeRef = robotKeySymbol.defaultType().toFirResolvedTypeRef()
     argumentMapping = buildAnnotationArgumentMapping {
-      mapping[Name.identifier("value")] = buildClassExpression(robotClassId, session)
+      mapping[Name.identifier("value")] = buildClassExpression(robotClass, session, compatContext)
     }
   }
 
@@ -542,6 +546,6 @@ public class ContributesRobotFir(session: FirSession) :
       session: FirSession,
       options: MetroOptions,
       compatContext: CompatContext,
-    ): MetroFirDeclarationGenerationExtension = ContributesRobotFir(session)
+    ): MetroFirDeclarationGenerationExtension = ContributesRobotFir(session, compatContext)
   }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/ralf/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
@@ -98,8 +98,12 @@ import software.ralf.app.platform.metro.compiler.fir.resolveTypeRef
  * binding methods. If the contributed class only implements `Scoped`, then `bindSuperType()` is
  * omitted and only the scoped multibinding is generated.
  */
-public class ContributesScopedFir(session: FirSession) :
-  MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+public class ContributesScopedFir
+internal constructor(
+  session: FirSession,
+  private val compatContext: CompatContext,
+) : MetroFirDeclarationGenerationExtension(session), MetroContributionHintExtension {
+  public constructor(session: FirSession) : this(session, CompatContext.create())
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(ContributesScopedIds.PREDICATE)
@@ -203,7 +207,7 @@ public class ContributesScopedFir(session: FirSession) :
         buildAnnotationCallWithArgument(
           classId = ClassIds.ORIGIN,
           argName = Name.identifier("value"),
-          argument = buildClassExpression(scopedOwner, session),
+          argument = buildClassExpression(scopedOwner, session, compatContext),
           containingSymbol = contributionSymbol,
           session = session,
         )
@@ -340,7 +344,7 @@ public class ContributesScopedFir(session: FirSession) :
           buildAnnotationCallWithArgument(
             ClassIds.SINGLE_IN,
             Name.identifier("scope"),
-            buildClassExpression(scopeClassId, session),
+            buildClassExpression(scopeClassId, session, compatContext, owner),
             functionSymbol,
             session,
           )
@@ -530,6 +534,6 @@ public class ContributesScopedFir(session: FirSession) :
       session: FirSession,
       options: MetroOptions,
       compatContext: CompatContext,
-    ): MetroFirDeclarationGenerationExtension = ContributesScopedFir(session)
+    ): MetroFirDeclarationGenerationExtension = ContributesScopedFir(session, compatContext)
   }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/kotlin/software/ralf/app/platform/metro/compiler/runners/AbstractBoxTest.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/kotlin/software/ralf/app/platform/metro/compiler/runners/AbstractBoxTest.kt
@@ -1,12 +1,11 @@
 package software.ralf.app.platform.metro.compiler.runners
 
 import org.jetbrains.kotlin.config.JvmTarget
-import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
-import org.jetbrains.kotlin.test.runners.codegen.AbstractFirBlackBoxCodegenTestBase
+import org.jetbrains.kotlin.test.runners.codegen.AbstractFirLightTreeBlackBoxCodegenTest
 import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 import software.ralf.app.platform.metro.compiler.services.configureKotlinTestImports
@@ -14,7 +13,7 @@ import software.ralf.app.platform.metro.compiler.services.configureMetroImports
 import software.ralf.app.platform.metro.compiler.services.configurePlugin
 import software.ralf.app.platform.metro.compiler.services.configureTestSupportClasspath
 
-open class AbstractBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree) {
+open class AbstractBoxTest : AbstractFirLightTreeBlackBoxCodegenTest() {
   override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
     return EnvironmentBasedStandardLibrariesPathProvider
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/explicitModelType.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/explicitModelType.kt
@@ -1,16 +1,31 @@
+// MODULE: model
+// FILE: Model.kt
 package com.test
 
-import software.ralf.app.platform.inject.ContributesRenderer
-import software.ralf.app.platform.metro.compiler.support.UnusedRendererFactory
 import software.ralf.app.platform.presenter.BaseModel
-import software.ralf.app.platform.renderer.Renderer
-import software.ralf.app.platform.renderer.RendererGraph
 
-class Model : BaseModel
+class Model : BaseModel {
+  companion object
+}
 
 class Model2 : BaseModel
 
-@ContributesRenderer(Model::class)
+// FILE: ModelAlias.kt
+package com.test.alias
+
+typealias ModelAlias = com.test.Model
+
+// MODULE: app(model)
+// FILE: app.kt
+package com.test
+
+import com.test.alias.ModelAlias
+import software.ralf.app.platform.inject.ContributesRenderer
+import software.ralf.app.platform.metro.compiler.support.UnusedRendererFactory
+import software.ralf.app.platform.renderer.Renderer
+import software.ralf.app.platform.renderer.RendererGraph
+
+@ContributesRenderer(ModelAlias::class)
 class TestRenderer : Renderer<Model2> {
   override fun render(model: Model2) = Unit
 }


### PR DESCRIPTION
It's already available from the extension integration anyway, so this just integrates it with the rest of AP's compiler usage to support a broader range.