### PR TITLE
Upgrade Metro to 1.4.3 and main-project build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- Upgrade Metro to `1.4.3`.
 - **Breaking change:** Rename the Molecule-specific presenter API to Compose-focused names, including `MoleculePresenter` to `ComposePresenter`, its scope APIs, Gradle DSL options, and `:presenter-molecule:*` artifacts to `:presenter-compose:*`.
 
 ### Deprecated

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.1"
+agp = "9.4.0"
 android-compileSdk = "37"
 # https://developer.android.com/jetpack/androidx/releases/compose-ui
 # https://maven.google.com/web/index.html#androidx.compose.ui:ui
@@ -14,7 +14,7 @@ androidx-annotations = "1.9.1"
 # Do not upgrade, which would force the higher version for consumers.
 androidx-collection = "1.5.0"
 # Align the app runtime with Android test dependencies.
-androidx-concurrent-futures = "1.2.0"
+androidx-concurrent-futures = "1.3.0"
 # Do not upgrade, which would force the higher version for consumers.
 androidx-lifecycle = "2.9.4"
 # Do not upgrade, which would force the higher version for consumers.
@@ -48,12 +48,12 @@ kotlin-compile-testing = "0.13.0"
 kotlin-hierarchy = "1.1"
 kotlin-inject = "0.9.0"
 kotlin-inject-anvil = "0.1.7"
-kotlin-poet = "2.3.0"
-kotlinx-binaryCompatibilityValidator = "0.18.1"
+kotlin-poet = "2.4.0"
+kotlinx-binaryCompatibilityValidator = "0.18.2"
 ktfmt = "0.64"
 ksp = "2.3.11"
 maven-publish = "0.37.0"
-metro = "1.4.2"
+metro = "1.4.3"
 molecule = "2.2.0"
 navigation-event = "1.1.0"
 navigation3 = "1.1.1"

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRendererProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRendererProcessor.kt
@@ -152,6 +152,12 @@ internal class ContributesRendererProcessor(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
             .addMetroOriginAnnotation(clazz)
+            // Preserve the generated graph interface API for consumers using warnings as errors.
+            .addAnnotation(
+              AnnotationSpec.builder(Suppress::class)
+                .addMember("%S", "CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
+                .build()
+            )
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", rendererScope)

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesScopedProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesScopedProcessor.kt
@@ -90,6 +90,12 @@ internal class ContributesScopedProcessor(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
             .addMetroOriginAnnotation(clazz)
+            // Preserve the generated graph interface API for consumers using warnings as errors.
+            .addAnnotation(
+              AnnotationSpec.builder(Suppress::class)
+                .addMember("%S", "CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
+                .build()
+            )
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", scopeClassName)

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.kt.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.kt.txt
@@ -23,7 +23,7 @@ class TestRenderer : Renderer<Model> {
       @IntoMap
       @RendererKey(value = Model::class)
       @CallableMetadata(callableName = "provideComTestTestRendererModel", propertyName = "", startOffset = 284, endOffset = 388)
-      fun provideComTestTestRendererModel2248969044_intomap(renderer: TestRenderer): Renderer<*> {
+      fun provideComTestTestRendererModel1500528963_intomap(renderer: TestRenderer): Renderer<*> {
         return error(message = "Never called")
       }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.kt.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.kt.txt
@@ -14,7 +14,7 @@ class TestRobot : Robot {
       @IntoMap
       @RobotKey(value = TestRobot::class)
       @CallableMetadata(callableName = "provideTestRobotIntoMap", propertyName = "", startOffset = 202, endOffset = 260)
-      fun provideTestRobotIntoMap2729140830_intomap(robot: TestRobot): Robot {
+      fun provideTestRobotIntoMap884116439_intomap(robot: TestRobot): Robot {
         return error(message = "Never called")
       }
 

--- a/presenter-compose/impl/src/androidMain/kotlin/software/ralf/app/platform/presenter/compose/AndroidComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/androidMain/kotlin/software/ralf/app/platform/presenter/compose/AndroidComposePresenterScopeFactory.kt
@@ -39,6 +39,7 @@ public interface AndroidComposePresenterScopeFactoryComponent {
 
 /** Provides the [AndroidComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface AndroidComposePresenterScopeFactoryGraph {
   /** Provides the [AndroidComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides

--- a/presenter-compose/impl/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenter.kt
+++ b/presenter-compose/impl/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenter.kt
@@ -29,6 +29,7 @@ public interface DefaultBackGestureDispatcherPresenterComponent {
  * [BackGestureDispatcherPresenter] for more details.
  */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface DefaultBackGestureDispatcherPresenterGraph {
   /** Provides a [BackGestureDispatcherPresenter] as singleton in the Metro graph. */
   @MetroProvides

--- a/presenter-compose/impl/src/desktopMain/kotlin/software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/desktopMain/kotlin/software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactory.kt
@@ -37,6 +37,7 @@ public interface DesktopComposePresenterScopeFactoryComponent {
 
 /** Provides the [DesktopComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface DesktopComposePresenterScopeFactoryGraph {
   /** Provides the [DesktopComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides

--- a/presenter-compose/impl/src/iosMain/kotlin/software/ralf/app/platform/presenter/compose/IosComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/iosMain/kotlin/software/ralf/app/platform/presenter/compose/IosComposePresenterScopeFactory.kt
@@ -37,6 +37,7 @@ public interface IosComposePresenterScopeFactoryComponent {
 
 /** Provides the [IosComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface IosComposePresenterScopeFactoryGraph {
   /** Provides the [IosComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides

--- a/presenter-compose/impl/src/linuxMain/kotlin/software/ralf/app/platform/presenter/compose/LinuxComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/linuxMain/kotlin/software/ralf/app/platform/presenter/compose/LinuxComposePresenterScopeFactory.kt
@@ -35,6 +35,7 @@ public interface LinuxComposePresenterScopeFactoryComponent {
 
 /** Provides the [LinuxComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface LinuxComposePresenterScopeFactoryGraph {
   /** Provides the [LinuxComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides

--- a/presenter-compose/impl/src/wasmJsMain/kotlin/software/ralf/app/platform/presenter/compose/WasmJsComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/wasmJsMain/kotlin/software/ralf/app/platform/presenter/compose/WasmJsComposePresenterScopeFactory.kt
@@ -37,6 +37,7 @@ public interface WasmJsComposePresenterScopeFactoryComponent {
 
 /** Provides the [WasmJsComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface WasmJsComposePresenterScopeFactoryGraph {
   /** Provides the [WasmJsComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides

--- a/renderer/public/api/desktop/public.api
+++ b/renderer/public/api/desktop/public.api
@@ -39,8 +39,8 @@ public abstract interface class software/ralf/app/platform/renderer/RendererGrap
 }
 
 public abstract class software/ralf/app/platform/renderer/RendererGraph$BindsMirror {
-	public final fun modelToRendererMapping_property6075157704205200196 ()Ljava/util/Map;
-	public final fun renderers_property4205200196 ()Ljava/util/Map;
+	public final fun modelToRendererMapping_property2182260457995712408 ()Ljava/util/Map;
+	public final fun renderers_property995712408 ()Ljava/util/Map;
 }
 
 public abstract interface class software/ralf/app/platform/renderer/RendererGraph$Factory {

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -15,7 +15,7 @@ public abstract interface class software/ralf/app/platform/robot/RobotGraph {
 }
 
 public abstract class software/ralf/app/platform/robot/RobotGraph$BindsMirror {
-	public final fun robots_property4205200196 ()Ljava/util/Map;
+	public final fun robots_property995712408 ()Ljava/util/Map;
 }
 
 public final class software/ralf/app/platform/robot/RobotKt {

--- a/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/RobotGraph.kt
+++ b/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/RobotGraph.kt
@@ -7,6 +7,7 @@ import kotlin.reflect.KClass
 
 /** Graph that provides all contributed [Robot] instances from the Metro dependency graph. */
 @ContributesTo(AppScope::class)
+@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface RobotGraph {
   /** All [Robot]s provided in the Metro dependency graph. */
   @Multibinds(allowEmpty = true) public val robots: Map<KClass<*>, () -> Robot>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.develocity" version "4.0.2"
+    id "com.gradle.develocity" version "4.5.0"
 }
 
 includeBuild('gradle-plugin') {


### PR DESCRIPTION
**Upgrade Metro to 1.4.3 and main-project build dependencies:**
Pick up Metro compiler fixes and align code generation with the existing Kotlin 2.4.20 and KSP 2.3.11 toolchain. Refresh the main build's Android tooling, API validator, and build-scan plugin. Keep the standalone blueprints unchanged and mention only Metro in `CHANGELOG.md`.

| Dependency | Upgrade | Target release date (UTC) |
|---|---|---|
| Android Gradle Plugin | `9.3.1` → `9.4.0` | 2026-09-01 |
| `androidx.concurrent:concurrent-futures` | `1.2.0` → `1.3.0` | 2025-07-16 |
| KotlinPoet | `2.3.0` → `2.4.0` | 2026-09-07 |
| Binary Compatibility Validator | `0.18.1` → `0.18.2` | 2026-09-02 |
| Metro | `1.4.2` → `1.4.3` | 2026-09-08 |
| Develocity | `4.0.2` → `4.5.0` | 2026-06-30 |

[Metro 1.4.3](https://github.com/ZacSweers/metro/releases/tag/1.4.3) fixes graph-extension resolution, contribution handling, annotation matching, and cross-module assisted injection, and is built against Kotlin 2.4.20. Its runtime still targets Kotlin 2.3.0 and its embedded Okio moves to 3.18.2. The new binding-container suggestion reaches App Platform's generated KSP interfaces; suppress that specific suggestion in the renderer and scoped generators to retain their existing interface API and support consumers compiling with warnings as errors. Regenerate the two changed compiler golden files and the renderer/robot desktop API snapshots for Metro's new generated member suffixes.

[KotlinPoet 2.4.0](https://github.com/square/kotlinpoet/releases/tag/2.4.0) adopts Kotlin 2.4.20 and KSP 2.3.11, fixes recursive generic handling and KSP type conversion, and changes annotation-array emission to bracket syntax. Its Kotlin standard-library and reflection requirements now match this repository. Both App Platform KSP processor implementations exercise these code-generation APIs.

[AGP 9.4.0](https://developer.android.com/build/releases/agp-9-4-0-release-notes) updates Android tooling and adds dynamic-feature variant-parity warnings. It requires Gradle 9.6.0 and JDK 17 and supports API 37, which fit the existing Gradle 9.7.1, JDK 25, and SDK 37 setup. The project has no dynamic feature modules. The published Gradle plugin's AGP API dependency remains `compileOnly`.

[Concurrent-futures 1.3.0](https://developer.android.com/jetpack/androidx/releases/concurrent#1.3.0) adds JSpecify nullness annotations and raises its AndroidX annotation dependency to 1.8.1, below this project's 1.9.1 pin. Its app-runtime constraint also controls Android test dependency alignment. [Binary Compatibility Validator 0.18.2](https://github.com/Kotlin/binary-compatibility-validator/releases/tag/0.18.2) prevents configuration failures on hosts unrecognized by Kotlin/Native without changing its declared runtime dependency.

[Develocity's intervening releases](https://gradle.com/help/gradle-plugin-release-history/) fix build-scan publication, Java 25 test retries, and configuration-cache/build-cache handling, and add resolved-artifact observability. The new 4.5.0 Quarkus test-distribution feature is not used here. The existing hosted build-scan configuration is supported.

No prior rollback of these declarations was found in the inspected repository history. Earlier Metro updates also required generated snapshot refreshes, and concurrent-futures was deliberately aligned with Android test resolution. The separate Metro compiler-compat PR #265 is left untouched.

No publicly discoverable target-version-specific blocker affecting current call sites was found as of 2026-09-08 in [Metro](https://github.com/ZacSweers/metro/issues?q=is%3Aissue+%221.4.3%22), [KotlinPoet](https://github.com/square/kotlinpoet/issues?q=is%3Aissue+%222.4.0%22), [BCV](https://github.com/Kotlin/binary-compatibility-validator/issues?q=is%3Aissue+%220.18.2%22), [Develocity integration samples](https://github.com/gradle/develocity-build-config-samples/issues?q=is%3Aissue+%224.5.0%22), and Android Issue Tracker searches for [AGP](https://issuetracker.google.com/issues?q=%22com.android.tools.build%3Agradle%22%20%229.4.0%22) and [concurrent-futures](https://issuetracker.google.com/issues?q=%22concurrent-futures%22%20%221.3.0%22). AGP's [signing-provider issue](https://issuetracker.google.com/issues/499166350) is marked fixed and the affected custom signing setup is absent here. Confidence is limited for the newly released Metro and KotlinPoet versions and for gated tracker content; Develocity's implementation is not publicly available in the searched sample repository.

**Preserve Metro graph interfaces under warnings-as-errors:**
Metro 1.4.3 suggests replacing binding-only contributed interfaces with binding containers. CI enables warnings-as-errors, so this new advisory diagnostic prevents the existing robot and presenter graph interfaces from compiling. Suppress only `CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER` on those public interfaces to preserve their API and graph inheritance across Android, Desktop, iOS, Linux, and Wasm.
