### PR TITLE
Replace Metro warning suppressions with binding containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Upgrade Metro to `1.4.3`.
+- **Breaking change:** Use Metro binding containers for presenter providers and KSP-generated renderer/scoped bindings; custom empty graphs implementing `RobotGraph` must include `RobotGraph.Bindings`.
 - **Breaking change:** Rename the Molecule-specific presenter API to Compose-focused names, including `MoleculePresenter` to `ComposePresenter`, its scope APIs, Gradle DSL options, and `:presenter-molecule:*` artifacts to `:presenter-compose:*`.
 
 ### Deprecated

--- a/docs/di.md
+++ b/docs/di.md
@@ -105,6 +105,13 @@ platform-specific source set or launcher module to provide platform-specific typ
 
 ### Platform implementations
 
+App Platform contributes provider-only declarations as Metro `@BindingContainer`s. These supply bindings
+without becoming supertypes of the assembled graph. The presenter provider types such as
+`DesktopComposePresenterScopeFactoryGraph` and `DefaultBackGestureDispatcherPresenterGraph` are objects;
+request their provided types through injected constructor parameters or graph accessors instead of casting
+the graph to a provider type. Recompile consumers after migrating from the former provider interfaces.
+The KSP-generated renderer and scoped contributions also use binding containers, matching the compiler-plugin path.
+
 Metro makes it simple to provide platform specific implementations for abstract APIs without needing
 to use `expect / actual` declarations or any specific wiring. Since the final object graphs live in
 platform-specific source sets or modules, all contributions for a platform are automatically picked up.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -306,6 +306,15 @@ Robots can be contributed to the application scope or any child scope. Robot loo
 and searches its children automatically. If multiple sibling scope instances provide the requested robot, lookup
 fails because the intended scope instance would be ambiguous.
 
+With Metro, `RobotGraph` exposes the robot factory map, while `RobotGraph.Bindings` declares that the map
+may be empty. Application-scope graphs include both automatically. A custom graph that explicitly implements
+`RobotGraph` and has no robot contributions must include the binding container:
+
+```kotlin
+@DependencyGraph(bindingContainers = [RobotGraph.Bindings::class])
+interface EmptyRobotGraph : RobotGraph
+```
+
 ??? info "Generated code"
 
     The `@ContributesRobot` annotation generates following code.

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRendererProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesRendererProcessor.kt
@@ -30,6 +30,7 @@ import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.Inject
@@ -46,8 +47,8 @@ import software.ralf.app.platform.renderer.metro.RendererKey
 /**
  * Generates the code for [ContributesRenderer].
  *
- * In the lookup package [METRO_LOOKUP_PACKAGE] a new interface is generated with a provider method
- * for the renderer, e.g.
+ * In the lookup package [METRO_LOOKUP_PACKAGE] a binding container is generated with a provider
+ * method for the renderer, e.g.
  *
  * ```
  * package software.ralf.test
@@ -61,7 +62,8 @@ import software.ralf.app.platform.renderer.metro.RendererKey
  * package $METRO_LOOKUP_PACKAGE.software.ralf.test
  *
  * @ContributesTo(RendererScope::class)
- * interface TestRendererGraph {
+ * @BindingContainer
+ * object TestRendererGraph {
  *     @Provides
  *     @IntoMap
  *     @RendererKey(Model::class)
@@ -110,12 +112,12 @@ internal class ContributesRendererProcessor(
         checkNoZeroArgInjectConstructor(it)
         checkSingleConstructorOrInject(it)
       }
-      .forEach { generateGraphInterface(it) }
+      .forEach { generateBindingContainer(it) }
 
     return emptyList()
   }
 
-  private fun generateGraphInterface(clazz: KSClassDeclaration) {
+  private fun generateBindingContainer(clazz: KSClassDeclaration) {
     val packageName = "${METRO_LOOKUP_PACKAGE}.${clazz.packageName.asString()}"
     val graphClassName = ClassName(packageName, "${clazz.innerClassNames()}Graph")
 
@@ -149,15 +151,10 @@ internal class ContributesRendererProcessor(
     val fileSpec =
       FileSpec.builder(graphClassName)
         .addType(
-          TypeSpec.interfaceBuilder(graphClassName)
+          TypeSpec.objectBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
             .addMetroOriginAnnotation(clazz)
-            // Preserve the generated graph interface API for consumers using warnings as errors.
-            .addAnnotation(
-              AnnotationSpec.builder(Suppress::class)
-                .addMember("%S", "CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-                .build()
-            )
+            .addAnnotation(BindingContainer::class)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", rendererScope)

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesScopedProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/ralf/app/platform/metro/processor/ContributesScopedProcessor.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.ContributesTo
@@ -43,6 +44,7 @@ import software.ralf.app.platform.metro.addMetroOriginAnnotation
  * package app.platform.inject.metro.software.ralf.test
  *
  * @ContributesTo(scope = AbcScope::class)
+ * @BindingContainer
  * public interface TestClassGraph {
  *
  *   @Binds
@@ -90,12 +92,7 @@ internal class ContributesScopedProcessor(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
             .addMetroOriginAnnotation(clazz)
-            // Preserve the generated graph interface API for consumers using warnings as errors.
-            .addAnnotation(
-              AnnotationSpec.builder(Suppress::class)
-                .addMember("%S", "CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-                .build()
-            )
+            .addAnnotation(BindingContainer::class)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", scopeClassName)
@@ -103,18 +100,22 @@ internal class ContributesScopedProcessor(
             )
             .apply {
               if (!clazz.hasInjectAnnotation()) {
-                addFunction(
-                  FunSpec.builder("provide${clazz.innerClassNames()}")
-                    .addAnnotation(Provides::class)
-                    .addAnnotations(
-                      clazz.annotations
-                        .filter { it.isMetroScopeAnnotation() }
-                        .map { it.toAnnotationSpec() }
-                        .toList()
+                addType(
+                  TypeSpec.companionObjectBuilder()
+                    .addFunction(
+                      FunSpec.builder("provide${clazz.innerClassNames()}")
+                        .addAnnotation(Provides::class)
+                        .addAnnotations(
+                          clazz.annotations
+                            .filter { it.isMetroScopeAnnotation() }
+                            .map { it.toAnnotationSpec() }
+                            .toList()
+                        )
+                        .returns(clazz.toClassName())
+                        .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                        .addCode(clazz.constructorCall())
+                        .build()
                     )
-                    .returns(clazz.toClassName())
-                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
-                    .addCode(clazz.constructorCall())
                     .build()
                 )
               }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
@@ -8,10 +8,12 @@ import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.containsOnly
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import assertk.assertions.startsWith
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.IntoMap
 import dev.zacsweers.metro.Provides
@@ -35,7 +37,7 @@ import software.ralf.test.TestRendererGraph
 class ContributesRendererProcessorTest {
 
   @Test
-  fun `a graph interface is generated in the lookup package for a contributed renderer`() {
+  fun `a binding container is generated in the lookup package for a contributed renderer`() {
     compile(
       """
       package software.ralf.test
@@ -56,6 +58,7 @@ class ContributesRendererProcessorTest {
       val generatedGraph = testRenderer.rendererGraph
 
       assertThat(generatedGraph.packageName).startsWith(METRO_LOOKUP_PACKAGE)
+      assertThat(generatedGraph).isAnnotatedWith(BindingContainer::class)
 
       with(
         generatedGraph.declaredNonSyntheticMethods.single {
@@ -93,8 +96,9 @@ class ContributesRendererProcessorTest {
         assertThat(getAnnotation(RendererKey::class.java).value).isEqualTo(model)
       }
 
-      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
-        .containsOnly(model)
+      val graph = graphInterface.newMetroGraph<TestRendererGraph>()
+      assertThat(generatedGraph.isAssignableFrom(graph.javaClass)).isFalse()
+      assertThat(graph.renderers.keys).containsOnly(model)
 
       assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.keys)
         .containsOnly(model)
@@ -105,7 +109,7 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated in the lookup package for a contributed renderer as inner class`() {
+  fun `a binding container is generated in the lookup package for a contributed renderer as inner class`() {
     compile(
       """
       package software.ralf.test
@@ -158,7 +162,7 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated in the lookup package for a contributed renderer with a model as inner class`() {
+  fun `a binding container is generated in the lookup package for a contributed renderer with a model as inner class`() {
     compile(
       """
       package software.ralf.test
@@ -623,7 +627,7 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated for constructor parameters without @Inject`() {
+  fun `a binding container is generated for constructor parameters without @Inject`() {
     compile(
       """
       package software.ralf.test

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/ralf/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
@@ -6,11 +6,13 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -28,7 +30,7 @@ import software.ralf.app.platform.scope.Scoped
 class ContributesScopedProcessorTest {
 
   @Test
-  fun `a graph interface is generated`() {
+  fun `a binding container is generated`() {
     compile(
       """
       package software.ralf.test
@@ -68,6 +70,8 @@ class ContributesScopedProcessorTest {
       assertThat(scopedGraph.getAnnotation(ContributesTo::class.java).scope)
         .isEqualTo(AppScope::class)
 
+      assertThat(scopedGraph).isAnnotatedWith(BindingContainer::class)
+
       // The annotations for these functions are defined in other kotlinc generated classes.
       // Instead of relying on reflection, we verify them by running the Metro compiler and
       // instantiating the Metro graph below.
@@ -82,6 +86,7 @@ class ContributesScopedProcessorTest {
       }
 
       val graph = graphInterface.newMetroGraph<Any>()
+      assertThat(scopedGraph.isAssignableFrom(graph.javaClass)).isFalse()
 
       @Suppress("UNCHECKED_CAST")
       val scopedInstances =
@@ -102,7 +107,7 @@ class ContributesScopedProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated for an inner class`() {
+  fun `a binding container is generated for an inner class`() {
     compile(
       """
       package software.ralf.test
@@ -143,7 +148,7 @@ class ContributesScopedProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated for constructor parameters without @Inject`() {
+  fun `a binding container is generated for constructor parameters without @Inject`() {
     compile(
       """
       package software.ralf.test
@@ -186,7 +191,8 @@ class ContributesScopedProcessorTest {
     ) {
       val scopedGraph = testClass.graph
 
-      with(scopedGraph.declaredNonSyntheticMethods.single { it.name == "provideTestClass" }) {
+      val companion = scopedGraph.declaredClasses.single { it.simpleName == "Companion" }
+      with(companion.declaredNonSyntheticMethods.single { it.name == "provideTestClass" }) {
         assertThat(parameters.single().type).isEqualTo(String::class.java)
         assertThat(returnType).isEqualTo(testClass)
         assertThat(this).isAnnotatedWith(Provides::class)
@@ -213,7 +219,7 @@ class ContributesScopedProcessorTest {
   }
 
   @Test
-  fun `a graph interface skips provider for an @Inject secondary constructor`() {
+  fun `a binding container skips provider for an @Inject secondary constructor`() {
     compile(
       """
       package software.ralf.test
@@ -260,10 +266,7 @@ class ContributesScopedProcessorTest {
     ) {
       val scopedGraph = testClass.graph
 
-      assertThat(
-          scopedGraph.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestClass" }
-        )
-        .isNull()
+      assertThat(scopedGraph.declaredClasses.singleOrNull { it.simpleName == "Companion" }).isNull()
 
       val graph = graphInterface.newMetroGraph<Any>()
 
@@ -280,7 +283,7 @@ class ContributesScopedProcessorTest {
   }
 
   @Test
-  fun `a graph interface is generated when only Scoped is implemented`() {
+  fun `a binding container is generated when only Scoped is implemented`() {
     compile(
       """
       package software.ralf.test

--- a/presenter-compose/impl/api/desktop/impl.api
+++ b/presenter-compose/impl/api/desktop/impl.api
@@ -13,29 +13,27 @@ public final class software/ralf/app/platform/presenter/compose/DesktopComposePr
 	public static fun provideDesktopComposePresenterScopeFactory (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryComponent;Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
 }
 
-public abstract interface class software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph {
-	public fun provideDesktopComposePresenterScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
-}
-
-public final class software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$DefaultImpls {
-	public static fun provideDesktopComposePresenterScopeFactory (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
+public final class software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph {
+	public static final field $stable I
+	public static final field INSTANCE Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;
+	public final fun provideDesktopComposePresenterScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
 }
 
 public final class software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field $stable I
 	public static final field Companion Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;)Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory;
 	public final fun declarationMirror (Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
-	public static final fun provideDesktopComposePresenterScopeFactory (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
+	public static final fun provideDesktopComposePresenterScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
 }
 
 public final class software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory$Companion {
 	public fun <init> ()V
-	public final fun create (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory;
-	public final fun provideDesktopComposePresenterScopeFactory (Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph;Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
+	public final fun create (Ldev/zacsweers/metro/Provider;)Lsoftware/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactoryGraph$ProvideDesktopComposePresenterScopeFactoryMetroFactory;
+	public final fun provideDesktopComposePresenterScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/ralf/app/platform/presenter/compose/ComposePresenterScopeFactory;
 }
 
 public abstract interface class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterComponent {
@@ -46,28 +44,19 @@ public final class software/ralf/app/platform/presenter/compose/backgesture/Defa
 	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterComponent;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
 }
 
-public abstract interface class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph {
-	public fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
-}
-
-public final class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$DefaultImpls {
-	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
+public final class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph {
+	public static final field $stable I
+	public static final field INSTANCE Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;
+	public final fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
 }
 
 public final class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field $stable I
-	public static final field Companion Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory;
+	public static final field INSTANCE Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory;
+	public static final fun create ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory;
 	public final fun declarationMirror ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
-	public static final fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
-}
-
-public final class software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory$Companion {
-	public fun <init> ()V
-	public final fun create (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenterMetroFactory;
-	public final fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
+	public static final fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/ralf/app/platform/presenter/compose/backgesture/BackGestureDispatcherPresenter;
 }
 

--- a/presenter-compose/impl/src/androidMain/kotlin/software/ralf/app/platform/presenter/compose/AndroidComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/androidMain/kotlin/software/ralf/app/platform/presenter/compose/AndroidComposePresenterScopeFactory.kt
@@ -3,6 +3,7 @@ package software.ralf.app.platform.presenter.compose
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionMode
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -39,8 +40,8 @@ public interface AndroidComposePresenterScopeFactoryComponent {
 
 /** Provides the [AndroidComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface AndroidComposePresenterScopeFactoryGraph {
+@BindingContainer
+public object AndroidComposePresenterScopeFactoryGraph {
   /** Provides the [AndroidComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/presenter-compose/impl/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenter.kt
+++ b/presenter-compose/impl/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/backgesture/DefaultBackGestureDispatcherPresenter.kt
@@ -1,6 +1,7 @@
 package software.ralf.app.platform.presenter.compose.backgesture
 
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -29,8 +30,8 @@ public interface DefaultBackGestureDispatcherPresenterComponent {
  * [BackGestureDispatcherPresenter] for more details.
  */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface DefaultBackGestureDispatcherPresenterGraph {
+@BindingContainer
+public object DefaultBackGestureDispatcherPresenterGraph {
   /** Provides a [BackGestureDispatcherPresenter] as singleton in the Metro graph. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/presenter-compose/impl/src/desktopMain/kotlin/software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/desktopMain/kotlin/software/ralf/app/platform/presenter/compose/DesktopComposePresenterScopeFactory.kt
@@ -2,6 +2,7 @@ package software.ralf.app.platform.presenter.compose
 
 import app.cash.molecule.RecompositionMode
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -37,8 +38,8 @@ public interface DesktopComposePresenterScopeFactoryComponent {
 
 /** Provides the [DesktopComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface DesktopComposePresenterScopeFactoryGraph {
+@BindingContainer
+public object DesktopComposePresenterScopeFactoryGraph {
   /** Provides the [DesktopComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/presenter-compose/impl/src/iosMain/kotlin/software/ralf/app/platform/presenter/compose/IosComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/iosMain/kotlin/software/ralf/app/platform/presenter/compose/IosComposePresenterScopeFactory.kt
@@ -3,6 +3,7 @@ package software.ralf.app.platform.presenter.compose
 import app.cash.molecule.DisplayLinkClock
 import app.cash.molecule.RecompositionMode
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -37,8 +38,8 @@ public interface IosComposePresenterScopeFactoryComponent {
 
 /** Provides the [IosComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface IosComposePresenterScopeFactoryGraph {
+@BindingContainer
+public object IosComposePresenterScopeFactoryGraph {
   /** Provides the [IosComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/presenter-compose/impl/src/linuxMain/kotlin/software/ralf/app/platform/presenter/compose/LinuxComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/linuxMain/kotlin/software/ralf/app/platform/presenter/compose/LinuxComposePresenterScopeFactory.kt
@@ -2,6 +2,7 @@ package software.ralf.app.platform.presenter.compose
 
 import app.cash.molecule.RecompositionMode
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -35,8 +36,8 @@ public interface LinuxComposePresenterScopeFactoryComponent {
 
 /** Provides the [LinuxComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface LinuxComposePresenterScopeFactoryGraph {
+@BindingContainer
+public object LinuxComposePresenterScopeFactoryGraph {
   /** Provides the [LinuxComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/presenter-compose/impl/src/wasmJsMain/kotlin/software/ralf/app/platform/presenter/compose/WasmJsComposePresenterScopeFactory.kt
+++ b/presenter-compose/impl/src/wasmJsMain/kotlin/software/ralf/app/platform/presenter/compose/WasmJsComposePresenterScopeFactory.kt
@@ -2,6 +2,7 @@ package software.ralf.app.platform.presenter.compose
 
 import app.cash.molecule.RecompositionMode
 import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo as MetroContributesTo
 import dev.zacsweers.metro.Provides as MetroProvides
 import dev.zacsweers.metro.SingleIn as MetroSingleIn
@@ -37,8 +38,8 @@ public interface WasmJsComposePresenterScopeFactoryComponent {
 
 /** Provides the [WasmJsComposePresenterScopeFactory] in the Metro graph. */
 @MetroContributesTo(MetroAppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
-public interface WasmJsComposePresenterScopeFactoryGraph {
+@BindingContainer
+public object WasmJsComposePresenterScopeFactoryGraph {
   /** Provides the [WasmJsComposePresenterScopeFactory] in the Metro graph as a singleton. */
   @MetroProvides
   @MetroSingleIn(MetroAppScope::class)

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -14,7 +14,11 @@ public abstract interface class software/ralf/app/platform/robot/RobotGraph {
 	public abstract fun getRobots ()Ljava/util/Map;
 }
 
-public abstract class software/ralf/app/platform/robot/RobotGraph$BindsMirror {
+public abstract interface class software/ralf/app/platform/robot/RobotGraph$Bindings {
+	public abstract fun getRobots ()Ljava/util/Map;
+}
+
+public abstract class software/ralf/app/platform/robot/RobotGraph$Bindings$BindsMirror {
 	public final fun robots_property995712408 ()Ljava/util/Map;
 }
 

--- a/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/RobotGraph.kt
+++ b/robot/public/src/commonMain/kotlin/software/ralf/app/platform/robot/RobotGraph.kt
@@ -1,14 +1,26 @@
 package software.ralf.app.platform.robot
 
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Multibinds
 import kotlin.reflect.KClass
 
 /** Graph that provides all contributed [Robot] instances from the Metro dependency graph. */
 @ContributesTo(AppScope::class)
-@Suppress("CONTRIBUTES_TO_COULD_BE_BINDING_CONTAINER")
 public interface RobotGraph {
   /** All [Robot]s provided in the Metro dependency graph. */
-  @Multibinds(allowEmpty = true) public val robots: Map<KClass<*>, () -> Robot>
+  public val robots: Map<KClass<*>, () -> Robot>
+
+  /**
+   * Allows graphs to expose an empty map when no robots are contributed. App-scope graphs include
+   * this container automatically. Other graphs implementing [RobotGraph] can include it through
+   * `@DependencyGraph(bindingContainers = [RobotGraph.Bindings::class])`.
+   */
+  @ContributesTo(AppScope::class)
+  @BindingContainer
+  public interface Bindings {
+    /** Declares the robot factory map without requiring any contributions. */
+    @Multibinds(allowEmpty = true) public val robots: Map<KClass<*>, () -> Robot>
+  }
 }

--- a/robot/public/src/commonTest/kotlin/software/ralf/app/platform/robot/RobotGraphTest.kt
+++ b/robot/public/src/commonTest/kotlin/software/ralf/app/platform/robot/RobotGraphTest.kt
@@ -1,0 +1,57 @@
+package software.ralf.app.platform.robot
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isSameInstanceAs
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.createGraph
+import kotlin.test.Test
+import software.ralf.app.platform.renderer.metro.RobotKey
+import software.ralf.app.platform.scope.Scope
+import software.ralf.app.platform.scope.di.metro.addMetroDependencyGraph
+
+class RobotGraphTest {
+
+  @Test
+  fun `application graphs expose an empty robot map without explicit wiring`() {
+    val graph = createGraph<EmptyAppGraph>() as RobotGraph
+
+    assertThat(graph.robots).isEmpty()
+  }
+
+  @Test
+  fun `custom graphs can include the empty robot map binding`() {
+    val graph = createGraph<EmptyCustomGraph>()
+
+    assertThat(graph.robots).isEmpty()
+  }
+
+  @Test
+  fun `robots from a custom child graph are found below an empty application graph`() {
+    val rootScope = Scope.buildRootScope {
+      addMetroDependencyGraph(createGraph<EmptyAppGraph>())
+    }
+    rootScope.buildChild("child") { addMetroDependencyGraph(createGraph<ChildGraph>()) }
+
+    try {
+      robot<TestRobot>(rootScope) { assertThat(this).isSameInstanceAs(TestRobot) }
+    } finally {
+      rootScope.destroy()
+    }
+  }
+
+  @DependencyGraph(AppScope::class) interface EmptyAppGraph
+
+  @DependencyGraph(bindingContainers = [RobotGraph.Bindings::class])
+  interface EmptyCustomGraph : RobotGraph
+
+  @DependencyGraph
+  interface ChildGraph : RobotGraph {
+    @Provides @IntoMap @RobotKey(TestRobot::class) fun provideRobot(): Robot = TestRobot
+  }
+
+  object TestRobot : Robot
+}


### PR DESCRIPTION
Metro 1.4.3 flags contributed interfaces that only declare bindings. Convert the presenter providers and KSP-generated renderer and scoped contributions to binding containers so builds can treat warnings as errors without suppressing that diagnostic.

Keep `RobotGraph` as an accessor and contribute its optional map through `RobotGraph.Bindings`, preserving application-scope and child-scope robot lookup. Custom empty graphs implementing `RobotGraph` must include that container, and consumers must recompile after the presenter provider interfaces become objects.

Stacked on #266.

