### PR TITLE
Preserve retained state after child recomposition

### DIFF
--- a/presenter-compose/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/WithLocalRetainedValuesStore.kt
+++ b/presenter-compose/public/src/commonMain/kotlin/software/ralf/app/platform/presenter/compose/WithLocalRetainedValuesStore.kt
@@ -42,19 +42,23 @@ public fun <R> withLocalRetainedValuesStore(
   store: RetainedValuesStore,
   content: @Composable () -> R,
 ): R {
-  val result = withCompositionLocal(LocalRetainedValuesStore provides store, content)
+  return withCompositionLocal(LocalRetainedValuesStore provides store) {
+    val result = content()
 
-  // Important: This must come AFTER the content for the underlying RememberObservers to dispatch
-  // in the correct order relative to retained values from the content block.
-  val composer = currentComposer
-  remember(store) { RetainContentPresenceIndicator(store, composer) }
-    .apply {
-      // Composer isn't guaranteed to stay the same between recompositions, make sure to update the
-      // reference just in case.
-      this.composer = composer
-    }
+    // Important: This must come AFTER the content for the underlying RememberObservers to dispatch
+    // in the correct order relative to retained values from the content block. It must also stay in
+    // the same composition-local group so that order is preserved after the content independently
+    // recomposes.
+    val composer = currentComposer
+    remember(store) { RetainContentPresenceIndicator(store, composer) }
+      .apply {
+        // Composer isn't guaranteed to stay the same between recompositions, make sure to update
+        // the reference just in case.
+        this.composer = composer
+      }
 
-  return result
+    result
+  }
 }
 
 private class RetainContentPresenceIndicator(

--- a/presenter-compose/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/compose/WithLocalRetainedValuesStoreTest.kt
+++ b/presenter-compose/public/src/commonTest/kotlin/software/ralf/app/platform/presenter/compose/WithLocalRetainedValuesStoreTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.retain.retainManagedRetainedValuesStore
+import androidx.compose.runtime.setValue
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -33,7 +35,7 @@ class WithLocalRetainedValuesStoreTest {
   }
 
   @Test
-  fun `retained child state returns after the child leaves composition`() = runTest {
+  fun `retained child state returns after the child recomposes and leaves composition`() = runTest {
     val showChild = MutableStateFlow(true)
     val presenter = ParentPresenter(ChildPresenter())
 
@@ -42,6 +44,8 @@ class WithLocalRetainedValuesStoreTest {
         assertThat(firstModel.count).isEqualTo(0)
         firstModel.onIncrement()
       }
+      assertThat(awaitItem()).isInstanceOf<Model.Child>().prop(Model.Child::count).isEqualTo(1)
+
       showChild.value = false
       assertThat(awaitItem()).isEqualTo(Model.Hidden)
 
@@ -80,12 +84,10 @@ class WithLocalRetainedValuesStoreTest {
   private class ChildPresenter : ComposePresenter<Unit, Model.Child> {
     @Composable
     override fun present(input: Unit): Model.Child {
-      val counter = retain { Counter() }
-      return Model.Child(count = counter.count, onIncrement = { counter.count++ })
+      var count by retain { mutableIntStateOf(0) }
+      return Model.Child(count = count, onIncrement = { count++ })
     }
   }
-
-  private class Counter(var count: Int = 0)
 
   private sealed interface Model : BaseModel {
     data object Hidden : Model


### PR DESCRIPTION
Keep the presence indicator in the same composition-local group as return-valued content so retained values are saved in the correct observer order after a child independently recomposes. Cover the failure with a snapshot-backed child that updates before leaving and re-entering composition.